### PR TITLE
Integrate Solana UTL for live tokens lists

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,7 +9,6 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   audit:
     # The type of runner that the job will run on
     runs-on: macos-latest
@@ -20,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: brew install librsvg libimagequant
       - run: npm install -g yarn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: brew install librsvg libimagequant
       - run: npm install -g yarn

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: brew install librsvg libimagequant
       - run: npm install -g yarn npm

--- a/.github/workflows/solana-tokenlist.yml
+++ b/.github/workflows/solana-tokenlist.yml
@@ -1,0 +1,49 @@
+name: Update Solana Unified Tokens List
+
+on:
+  schedule:
+    # Runs "at 00:00 every day"
+      - cron: '0 0 * * *'
+
+env:
+  TOKEN_LISTS_ACTIONS_OR_CI_BUILD: true
+
+jobs:
+  generate:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Extract branch name
+        shell: bash
+        run: echo "GITHUB_BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: brew install librsvg libimagequant
+
+      - run: npm install -g yarn
+      - run: yarn
+
+      - run: yarn gen:solana
+        env:
+          SOLANA_MAINNET_RPC_URL: ${{ secrets.SOLANA_MAINNET_RPC_URL }}
+          TRUSTED_TOKEN_LIST_URL: https://cdn.jsdelivr.net/gh/brave/token-lists@${{ steps.extract_branch.outputs.GITHUB_BRANCH }}/data/solana/trusted-tokenlist.json
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update Solana UTL
+          file_pattern: 'data/solana/tokenlist.json'
+
+      - name: 'Automated Version Bump'
+        uses: 'phips28/gh-action-bump-version@master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - run: yarn start
+
+      - run: npm run publish-token-package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/data/solana/tokenlist.json
+++ b/data/solana/tokenlist.json
@@ -1,0 +1,7759 @@
+{
+  "name": "Solana Token List",
+  "logoURI": "",
+  "keywords": [
+    "solana",
+    "spl"
+  ],
+  "tags": {
+    "lp-token": {
+      "name": "lp-token",
+      "description": ""
+    }
+  },
+  "timestamp": "2023-02-04T11:32:24.099Z",
+  "tokens": [
+    {
+      "chainId": 101,
+      "name": "Basic Attention Token (Portal)",
+      "symbol": "BAT",
+      "address": "EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz/logo.png",
+      "tags": [
+        "wrapped",
+        "wormhole"
+      ],
+      "verified": true,
+      "holders": null
+    },
+    {
+      "chainId": 101,
+      "name": "1SAFU",
+      "symbol": "SAFU",
+      "address": "GWgwUUrgai3BFeEJZp7bdsBSYiuDqNmHf9uRusWsf3Yi",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/22792/large/145941796-8f7716f4-66bc-4a38-9ad5-441525c3b5b2.png?1642581127",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "1safu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "1sol.io (Wormhole)",
+      "symbol": "1SOL",
+      "address": "4ThReWAbAVZjNVgs5Ui9Pk3cZ5TYaD9u6Y89fp6EFzoF",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22923/large/1SOL_wh_small.png?1644222565",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "1sol-io-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ABC Floor Index",
+      "symbol": "ABC",
+      "address": "EKLq86cHRwc8Spkcx2noPnfoVyQvcWSeud5JMJnTxNAD",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27172/large/abc.png?1662287244",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "abc-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Access Protocol",
+      "symbol": "ACS",
+      "address": "5MAYDfq5yxtudAhtfyuMBuHZjgAbaS9tbEyEQYAhDS5y",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28747/large/dR4FovX4_400x400.jpg?1673860839",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "access-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Agronomist",
+      "symbol": "AGTE",
+      "address": "4QV4wzDdy7S1EV6y2r9DkmaDsHeoKz6HUvFLVtAsu6dV",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18314/large/logogecko.png?1631515498",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "agronomist"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Aldrin",
+      "symbol": "RIN",
+      "address": "E5ndSkaB17Dm7CsD22dvcjfrYSDLCxFcMd6z8ddCk5wp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16849/large/Aldrin.png?1629959768",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "aldrin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Alien Chicken Farm",
+      "symbol": "ACF",
+      "address": "2cZv8HrgcWSvC6n1uEiS48cEQGb1d3fiowP2rpa4wBL9",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/25441/large/acf-token_%281%29.png?1651760005",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "alien-chicken-farm"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ALL.ART",
+      "symbol": "AART",
+      "address": "F3nefJBcejYbtdREjui1T9DPh5dBgpkKq7u2GAAMXs5B",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22012/large/all-art.PNG?1640590472",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "all-art"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Allbridge",
+      "symbol": "ABR",
+      "address": "a11bdAAuV8iB2fu7X6AxAvDTo1QZ8FXB3kk5eecdasp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18690/large/abr.png?1640742053",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "allbridge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Almond",
+      "symbol": "ALM",
+      "address": "ALMmmmbt5KNrPPUBFE4dAKUKSPWTop5s3kUGCdF69gmw",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20348/large/logo_-_2021-11-15T102036.111.png?1636942845",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "almond"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Amulet Staked SOL",
+      "symbol": "AMTSOL",
+      "address": "SoLW9muuNQmEAoBws7CWfYQnXRXMVEG12cQhy6LE2Zf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27786/large/amtSOL200x200.png?1665814113",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "amulet-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ApeXit Finance",
+      "symbol": "APEX",
+      "address": "51tMb3zBKDiQhNwGqpgwbavaGH54mk8fXFzxTc1xnasg",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16864/large/cg.png?1625470996",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "apexit-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Apple Fruit",
+      "symbol": "APPLE",
+      "address": "8E5W9PMhnEvdvM2Q9XBLMJW7UsFiieXnRHPj8zhtB23h",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20116/large/9pfJYwQk_400x400.jpg?1636521578",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "apple-fruit"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Apricot",
+      "symbol": "APRT",
+      "address": "APTtJyaRX5yGTsJU522N4VYWg3vCvSb65eam5GrPT5Rt",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20636/large/hF_3FMuH_400x400.jpg?1637399870",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "apricot"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "APYSwap",
+      "symbol": "APYS",
+      "address": "5JnZ667P3VcjDinkJFysWh2K2KtViy63FZ3oL5YghEhW",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14163/large/apys.png?1635831990",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "apyswap"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ARB Protocol",
+      "symbol": "ARB",
+      "address": "9tzZzEHsKnwFL1A3DyFJwj36KnZj3gZ7g4srWp9YTEoh",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26046/large/IMG_3600.png?1656916820",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "arb-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Arenum",
+      "symbol": "ARNM",
+      "address": "3Dy8KFyvpUJ8nfRCbvk4HLWjNRRzxiVhTeE9PQF9RARD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24393/large/6253dcf123d4f40001e9c793_CryptoCoin_1024.png?1649733527",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "arenum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ARTE",
+      "symbol": "ARTE",
+      "address": "6Dujewcxn1qCd6rcj448SXQL9YYqTcqZCNQdCn3xJAKS",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23556/large/token_200.png?1644473079",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "arte"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ArtiCoin",
+      "symbol": "ATC",
+      "address": "GXnw9YSt6DANCt84Ti6ZpbaXvrvuEJFCYqrDjygnq4R8",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25232/large/LOGO-256.png?1650953344",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "articoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ashera",
+      "symbol": "ASH",
+      "address": "FY6XDSCubMhpkU9FAsUjB7jmN8YHYZGezHTWo9RHBSyX",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/18508/large/ashera.png?1635150588",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ashera"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Astrals GLXY",
+      "symbol": "GLXY",
+      "address": "CJ5U6wPmjxFUyTJpUTS7Rt1UqhTmSVRMvmJ8WD4nndXW",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25389/large/glxy.png?1651661031",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "astrals-glxy"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "AstraPad",
+      "symbol": "ASTRA",
+      "address": "AMp8Jo18ZjK2tuQGfjKAkkWnVP4NWX5sav4NJH6pXF2D",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20028/large/WzDPqfV.png?1636418940",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "astrapad"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Atlas DEX",
+      "symbol": "ATS",
+      "address": "HJbNXx2YMRxgfUJ6K4qeWtjatMK5KYQT1QnsCdDWywNv",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23002/large/logo.png?1643091340",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "atlas-dex"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "AtPay",
+      "symbol": "ATPAY",
+      "address": "CWBzupvyXN1Cf5rsBEHbzfTFvreLfUaJ77BMNLVJ739y",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27254/large/atpay.png?1663049746",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "atpay"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Audius (Wormhole)",
+      "symbol": "AUDIO",
+      "address": "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22936/large/AUDIO_wh_small.png?1644224294",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "audius-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Aurory",
+      "symbol": "AURY",
+      "address": "AURYydfxJib1ZkTir1Jn1J9ECYUtjb6rKQVmtYaixWPP",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19324/large/Ico_Blanc.png?1672824647",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "aurory"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Avalanche (Wormhole)",
+      "symbol": "AVAX",
+      "address": "KgV1GvrHQmRBY8sHQQeUKwTm2r2h8t4C8qt12Cw1HVE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22943/large/AVAX_wh_small.png?1644224391",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "avalanche-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Avenue Hamilton Token",
+      "symbol": "AHT",
+      "address": "AHT1yynTv45s3P3KrRfQCVMHckdHeMVA3fteEg34xt9y",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28086/large/7FbZmTSKMsSqtlfe8yH1n3QgdBc3RBBt0B6dsdprVBs.png?1667724654",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "avenue-hamilton-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Avenue University Token",
+      "symbol": "AUT",
+      "address": "AUT1gfMZw37wMMQqAxk89nfpjZpEEf2XSoBUd8V5ydnS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28087/large/T-R84Zo32rDOA5Wo66T8jAlqcyjD7Folt1oeCfjlizU.png?1667724695",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "avenue-university-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "AvocadoCoin",
+      "symbol": "AVDO",
+      "address": "EE5L8cMU4itTsCSuor7NLK6RZx6JhsBe8GGV3oaAHm3P",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23675/large/PNLL1B2g_400x400.jpg?1644996225",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "avocadocoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Axie Infinity Shard (Wormhole)",
+      "symbol": "AXSET",
+      "address": "HysWcbHiYY9888pHbaqhwLYZQeZrcQMXKQWRqS7zcPK5",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22952/large/AXSet_wh_small.png?1644224450",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "axie-infinity-shard-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Baby Samo Coin",
+      "symbol": "BABY",
+      "address": "Uuc6hiKT9Y6ASoqs2phonGGw2LAtecfJu9yEohppzWH",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20262/large/386VuTho_400x400.jpg?1636704021",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "baby-samo-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "BabyTigerGold",
+      "symbol": "BABYTIGER",
+      "address": "8JjBJdV73zPPmZvkgC91ni8RsbXWTkhpuSdxeZgaw6hD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22811/large/logo_babytiger.png?1642658264",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "babytigergold"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Balisari",
+      "symbol": "BST",
+      "address": "EYDEQW4xQzLqHcFwHTgGvpdjsa5EFn74KzuqLX5emjD2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19852/large/balisari-1.jpg?1636061685",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "balisari"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Balloonsville AIR",
+      "symbol": "AIR",
+      "address": "E6eCEE3KqjRD5UxcBYQTdV8Z535hyaBuFin9Udm6s6bz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24853/large/9CmgcH6.png?1649134566",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "balloonsville-air"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bamboo Coin",
+      "symbol": "BMBO",
+      "address": "5sM9xxcBTM9rWza6nEgq2cShA87JjTBx1Cu82LjgmaEg",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19620/large/FC0hnduacAAHYFC.png?1635496724",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bamboo-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Banana Bucks",
+      "symbol": "BAB",
+      "address": "2Dzzc14S1D7cEFGJyMZMACuoQRHVUYFhVE74C5o8Fwau",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20592/large/_BAB_coinmedium.png?1637285029",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "banana-bucks"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bancambios AX",
+      "symbol": "BXS",
+      "address": "pH5wWJc3KhdeVQSt86DU31pdcL9c8P88x2FQoKEJVHC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25644/large/81660481.png?1652949329",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bancambios-ax"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "basis.markets",
+      "symbol": "BASIS",
+      "address": "Basis9oJw9j8cw53oMV7iqsgo6ihi9ALw4QR31rcjUJa",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21444/large/tkQevyc.png?1653297101",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "basis-markets"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Battle of Guardians Share",
+      "symbol": "BGS",
+      "address": "At7RLMbA6ZUjj7riyvFq2j5NHQ19aJabCju2VxLDAqso",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22285/large/K3hU77wS_400x400.jpg?1641365642",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "battle-of-guardians-share"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Big Defi Energy",
+      "symbol": "BDE",
+      "address": "H5gczCNbrtso6BqGKihF97RaWaxpUEZnFuFUKK4YX3s2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17903/large/bde.png?1636333319",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "big-defi-energy"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "BiLira",
+      "symbol": "TRYB",
+      "address": "A94X2fRy3wydNShU4dRaDyap2UuoeWJGWyATtyp61WZf",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/10119/large/JBs9jiXO_400x400.jpg?1642668342",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bilira"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Binance Coin (Wormhole)",
+      "symbol": "BNB",
+      "address": "9gP2kCy3wA1ctvYWQk75guqXuHfrEomqydHLtcTCqiLa",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22884/large/BNB_wh_small.png?1644224553",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "binance-coin-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bird.Money",
+      "symbol": "BIRD",
+      "address": "FTPnEQ3NfRRZ9tvmpDW6JFrvweBE5sanxnXSpJL1dvbB",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/13260/large/favicon-180x180.png?1611546646",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bird-money"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bitmon",
+      "symbol": "BIT",
+      "address": "EGiWZhNk3vUNJr35MbL2tY5YD6D81VVZghR2LgEFyXZh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25282/large/BT-logo.png?1651127844",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bitmon"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bitspawn",
+      "symbol": "SPWN",
+      "address": "5U9QqCPhqXAJcEv9uyzFJd5zhN93vuPk1aNNkXnUfPnt",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16513/large/token_logo.png?1631603192",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bitspawn"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Black Label",
+      "symbol": "KLB",
+      "address": "4NPzwMK2gfgQ6rTv8x4EE1ZvKW6MYyYTSrAZCx7zxyaX",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/18489/large/klb_round_200.png?1632184288",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "black-label"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "BlazeStake Staked SOL",
+      "symbol": "BSOL",
+      "address": "bSo13r4TkiE4KumL71LsHTPpL2euBYLFx6h9HP3piy1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26636/large/blazesolana.png?1659328728",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "blazestake-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Blockasset",
+      "symbol": "BLOCK",
+      "address": "NFTUkR4u7wKxy9QLaX2TGvd9oZSWoMo4jqSJqdMb7Nk",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21332/large/Blockasset-Logo-Symbol.png?1648442722",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "blockasset"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Blocksmith Labs Forge",
+      "symbol": "$FORGE",
+      "address": "FoRGERiW7odcCBGU1bztZi16osPBHjxharvDathL5eds",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25411/large/Logo_%281%29.png?1651733020",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "blocksmith-labs-forge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Blocto",
+      "symbol": "BLT",
+      "address": "BLT1noyNr3GttckEVrtcfC6oyK6yV1DpPgSyXbncMwef",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/18657/large/BLT_token.png?1633082645",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "blocto-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "bofb",
+      "symbol": "BOFB",
+      "address": "45wdSjpSqZCk9mkqmq5Nh7beCEqqUJMJcVduwYCip5eq",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/24866/large/2qsZgpxd_400x400.jpg?1649166378",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bofb"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boryoku Dragonz",
+      "symbol": "BOKU",
+      "address": "CN7qFa5iYkHz99PTctvT4xXUHnxwjQ5MHxCuTJtPN5uS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20820/large/ZdgsxFPV_400x400.png?1637721291",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "boku"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boleld",
+      "symbol": "BOLE",
+      "address": "7uv3ZvZcQLd95bUp5WMioxG7tyAZVXFfr8JYkwhMYrnt",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/16317/large/Bole.png?1623736184",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bole-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bonfida",
+      "symbol": "FIDA",
+      "address": "EchesyfXePKdLtoiZSL8pBe8Myagyy8ZRqsACNCFGnvp",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/13395/large/bonfida.png?1658327819",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bonfida"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bonk",
+      "symbol": "BONK",
+      "address": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28600/large/bonk.jpg?1672304290",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bonk"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boo",
+      "symbol": "BOO",
+      "address": "FfpyoV365c7iR8QQg5NHGCXQfahbqzY67B3wpzXkiLXr",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28778/large/circle_BOO_logo.png?1674112115",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "boo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bored Ape Social Club",
+      "symbol": "BAPE",
+      "address": "BgeRyFWWGHeVouqfHfcXUxmvfkgekhrXYVqQWf63kpJB",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23734/large/DY4jjsMH_400x400.jpg?1645173802",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bored-ape-social-club"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boring Protocol",
+      "symbol": "BOP",
+      "address": "BLwTnYKqf7u4qjgZrrsKeNs2EzWkMLqVCu6j8iHyrNA3",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/16828/large/imgonline-com-ua-resize-VT59gqn-Bya-WGG.jpg?1625210880",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "boring-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bork",
+      "symbol": "BORK",
+      "address": "2LxZrcJJhzcAju1FBHuGvw929EVkX7R7Q8yA2cdp8q7b",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19951/large/VtJL5kdepu6AyVHnHi4GImgyWxmcb2XMPN7jURW_yXQ.png?1636338300",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bork"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boryoku Genesis Dragonz Index",
+      "symbol": "DRGNZ",
+      "address": "CzXF8oUJSsB9ADKV99WAi2TgytqAyKvQw6EihwiL9em4",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24386/large/AzJI7FQ.png?1647501836",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "boryoku-genesis-dragonz-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bounty",
+      "symbol": "BNTY",
+      "address": "BNTY5DaMP9CZhEtmQfMLHfUwwkXropHuCz4m96YqpqKm",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24975/large/bnty.png?1649652061",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bounty"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Boxch",
+      "symbol": "BOXCH",
+      "address": "Boxch1343xWQWbahVBPhYHuYLXNHnWYHG6QbuqfNugQ1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26119/large/Group_212.png?1667726216",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "boxch"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bracelet",
+      "symbol": "BRC",
+      "address": "E69gzpKjxMF9p7u4aEpsbuHevJK9nzxXFdUDzKE5wK6z",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28866/large/bracelet-token.png?1674996027",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bracelet"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bridgesplit Brand Index",
+      "symbol": "BBI",
+      "address": "GRsoqmhsS7fCLpEqqE7oRM92ag3WVy8VbJAi6KfWSeHS",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/25640/large/a.png?1652942415",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bridgesplit-brand-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Brazilian Digital",
+      "symbol": "BRZ",
+      "address": "FtgGSFADXBtroxq8VCausXRr2of47QBf5AS1NtZCu4GD",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/8472/large/MicrosoftTeams-image_%286%29.png?1674480131",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "brz"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Buff Samo",
+      "symbol": "BSAMO",
+      "address": "2XSuy8RSESbtYRBbVHxGWuoikn3B6iXKVKzN4i3owTCf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20597/large/logo_-_2021-11-19T094813.378.png?1637286506",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "buff-samo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Bulldog Billionaires",
+      "symbol": "BONE",
+      "address": "D3eyBjfgJMPHZyYDRtbf1cSxeLiNwKumwHzQK3h3TRRq",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24560/large/MIBYsiqF_400x400.jpg?1648195687",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bulldog-billionaires"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "BunnyDucky",
+      "symbol": "BUD",
+      "address": "BUD1144GGYwmMRFs4Whjfkom5UHqC9a8dZHPVvR2vfPx",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25934/large/bdlogo.png?1654758682",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "bunnyducky"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Burrito Boyz Floor Index",
+      "symbol": "BURR",
+      "address": "XwTZraiF1dVh69cZ2SpqyjDLmei2uVps5CYHD9vqK6d",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27169/large/7ryKn0fdux0PnpBEiwmop9DaFq2KG8WHmGhhtOYPoAU.png?1662286753",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "burrito-boyz-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Capybara",
+      "symbol": "CAPY",
+      "address": "CAPYD6Lrm7bTZ6C7t7JvSxvpEcfKQ9YNB7kUjh6p6XBN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22000/large/logo_-_2021-12-27T143844.581.png?1640587159",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "capybara"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Care Coin",
+      "symbol": "CRC",
+      "address": "z9WZXekbCtwoxyfAwEJn1euXybvqLzPVv3NDzJzkq7C",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18836/large/nyZmFyL1_400x400.jpg?1633570319",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "care-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Catalina Whales Index",
+      "symbol": "WHALES",
+      "address": "DSXWF79VQ3RzFBB67WeNfCzfzAQq5X6m97zi85bq1TRx",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27053/large/whales.png?1661507402",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "catalina-whales-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CATO",
+      "symbol": "CATO",
+      "address": "5p2zjqCd1WJzAVgcEnjhb9zWDU7b9XVhFhx4usiyN7jB",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17031/large/CATO200newlogo.png?1648448136",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cato"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CaveWorld",
+      "symbol": "CAVE",
+      "address": "4SZjjNABoqhbd4hnapbvoEPEqT8mnNkfbEoAwALf1V8t",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19358/large/token.png?1650866628",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cave"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Charactbit",
+      "symbol": "CHB",
+      "address": "YtfMZ4jg2ubdz4GasY86iuGjHdo5rCPJnFqgSf8gxAz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24863/large/200x_logo.png?1649165917",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "charactbit"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cheems",
+      "symbol": "CHEEMS",
+      "address": "3FoUAsGDbvTD6YZ4wVKJgTB76onJUKz7GPEBNiR5b8wc",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/18358/large/newlogo.png?1644476666",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cheems"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CheeseSoda",
+      "symbol": "SODA",
+      "address": "sodaNXUbtjMvHe9c5Uw7o7VAcVpXPHAvtaRaiPVJQuE",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/18451/large/soda_200.png?1632093508",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cheesesoda-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ChihuahuaSol",
+      "symbol": "CHIH",
+      "address": "6xtyNYX6Rf4Kp3629X11m1jqUmkV89mf9xQakUtUQfHq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20528/large/rsz_chihuahua-token.png?1637200907",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "chihuahuasol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ChikinCoin",
+      "symbol": "CKC",
+      "address": "8s9FCz99Wcr3dHpiauFRi6bLXzshXfcGTfgQE7UEopVx",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24978/large/Screenshot_from_2022-04-11_15-47-44.png?1649663281",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "chikincoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CHILI",
+      "symbol": "CHILI",
+      "address": "GPyzPHuFFGvN4yWWixt6TYUtDG49gfMdFFi2iniTmCkh",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/28668/large/CHILI_start.png?1672995567",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "chili"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nana",
+      "symbol": "NANA",
+      "address": "6uZ7MRGGf3FJhzk9TUk3QRMR2fz83WY9BEVBukRvMRVX",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22407/large/200x200.png?1641967515",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "chimp-fight"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CHUG",
+      "symbol": "CHUG",
+      "address": "CbDwU8JrTYv3GzU7msni8qtfFkAGpcyFAzuhuGq5SVqp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22474/large/chug.png?1641885210",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "chug-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Clash",
+      "symbol": "CLH",
+      "address": "CLAsHPfTPpsXmzZzdexdEuKeRzZrWjZFRHQEPu2kSgWM",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27836/large/New-Clash-Icon_copy.png?1665996878",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "clash"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Clash Of Cars",
+      "symbol": "CLASH",
+      "address": "3aAYh35n81F8HPG2QBdE48aYdzGFj2fsLccg91X4AcRc",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23307/large/logo_%286%29.png?1643697035",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "clash-of-cars"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ClinTex CTi",
+      "symbol": "CTI",
+      "address": "9ET2QCQJdFkeKkuaampNbmicbA8eLYauFCWch9Ddh9p5",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13266/large/CTI.png?1606817542",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "clintex-cti"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "COBAN",
+      "symbol": "COBAN",
+      "address": "7udMmYXh6cuWVY6qQVCd9b429wDVn2J71r5BdxHkQADY",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/19483/large/coban-logo-pebyyxjzxvebwa8nsvpp9t8iple69h6enp9bdknotq.png?1635285761",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "coban"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Codi Finance",
+      "symbol": "CODI",
+      "address": "yvbrxE6zjrA8SxxSpL7oojDBB5QDmF5CVqJWea8JcQE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22798/large/ovFr4h_Y_n8q_1RIgfg5IFCRtx56Uc0R-GC9LiIcy1HOgigf0mYH2kWVFuvBipErCvpnrp0yps4Y3XTis-boKJg_2_ucFmv3Iu0CaSyCXThFihx-yrr9vo7t0HEL5optQ6jKAXpSLtXvKZPHrmMgMM2VFB2D4UCPxGsCItv6kvSix3LsjLcrKmTAvmHLvCby1om1BvKJLFcXP0.jpg?1642582521",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "codi-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Coin98",
+      "symbol": "C98",
+      "address": "C98A4nkJXhpVZNAZdHUA95RpTF3T4whtQubL3YobiUX9",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17117/large/logo.png?1626412904",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "coin98"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Coin98 Dollar",
+      "symbol": "CUSD",
+      "address": "CUSDvqAQLbt7fRofcmV2EXfPA2t36kzj7FjzdmqDiNQL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26588/large/CUSD-01.png?1658909049",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "coin98-dollar"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Companion",
+      "symbol": "CMPN",
+      "address": "9tQhCmFtCh56qqf9szLQ8dNjYcd4TTv6MWPpw6MqLubu",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27914/large/cmpn.png?1666343810",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "companion"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Compendium",
+      "symbol": "CMFI",
+      "address": "5Wsd311hY8NXQhkt9cWHwTnqafk7BGEbLu8Py3DSnPAr",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22269/large/CMFI-Token-Logo-Compendium-Finance.png?1674728282",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "compendium-fi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ConstitutionDAO (Wormhole)",
+      "symbol": "PEOPLE",
+      "address": "CobcsUrt3p91FwvULYKorQejgsm5HoQdv5T8RUZ6PnLA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23009/large/PEOPLE_wh_small.png?1644226832",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "constitutiondao-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cope",
+      "symbol": "COPE",
+      "address": "8HGyAAB1yoM1ttS7pXjHMa3dukTFGQggnFFH3hJZgzQh",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14567/large/COPE.png?1617162230",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cope"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cope Token",
+      "symbol": "COPE",
+      "address": "o1Mw5Y3n68o8TakZFuGKLZMGjm72qv4JeoZvGiCLEvK",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/28717/large/coingecko.png?1673576722",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cope-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CoreStarter",
+      "symbol": "CSTR",
+      "address": "G7uYedVqFy97mzjygebnmmaMUVxWHFhNZotY6Zzsprvf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20209/large/cstr.png?1636642782",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "corestarter"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Corni",
+      "symbol": "CORNI",
+      "address": "FYNmEg12xqyuNrRn8A1cqkEapcUCh3M7ZARUN1yj1bEs",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27901/large/corni_logo_m.png?1666330995",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "corni"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cosmic Ape Coin",
+      "symbol": "CAC",
+      "address": "E1s2muWwiLT2n3EQUL27hgviaPRRXWkpXD7ShpfgRvVz",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22570/large/Cosmic-Ape-Logosc.png?1643186237",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cosmic-ape-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Creamy",
+      "symbol": "CREAMY",
+      "address": "CREAMpdDimXxj2zTCwP5wMEtba4NYaKCrTBEQTSKtqHe",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25285/large/logo200.png?1651128831",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "creamy"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cricket Star Manager",
+      "symbol": "CSM",
+      "address": "EzfnjRUKtc5vweE1GCLdHV4MkDQ3ebSpQXLobSKgQ9RB",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25774/large/CSM_token.png?1653631158",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cricket-star-manager"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cripco",
+      "symbol": "IP3",
+      "address": "3uejHm24sWmniGA5m4j4S1DVuGqzYBR5DJpevND4mivq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26344/large/f55kBYa2_400x400.jpeg?1657586586",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cripco"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "CropperFinance",
+      "symbol": "CRP",
+      "address": "DubwWZNWiNGMMeeQHPnMATNj77YZPZSAz2WVR5WjLJqz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17883/large/copperfinance.PNG?1629708744",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cropperfinance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Crowny",
+      "symbol": "CRWNY",
+      "address": "CRWNYkqdgvhGGae9CKfNka58j6QQkaD5bLhKXvUYqnc1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14958/large/crowny-icon-rounded_2x.png?1619147225",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "crowny-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cry Cat Coin",
+      "symbol": "CRYY",
+      "address": "56tNQ29XBrbovm5K5SThuQatjCy92w2wKUaUeQ8WCD9g",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22128/large/cry_logo_200_200.png?1640870275",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cry-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cryowar",
+      "symbol": "CWAR",
+      "address": "HfYFjMKNZygfMC8LsQ8LtpPsPxEJoXJx4M6tqi75Hajo",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20227/large/CWAR_round_200_200.png?1636689418",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cryowar-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Crypto Mushroomz",
+      "symbol": "SHROOMZ",
+      "address": "2vRgBSJEVPXxayrhXoazQyCKSGFYQG3ZdfT2Gv5gZykL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20990/large/6k8KBF3H_400x400.png?1638170123",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "crypto-mushroomz"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Curate",
+      "symbol": "XCUR",
+      "address": "35r2jMGKytAJ7FyKfKRHPanT8kpjg3emPy7WG6GANCNB",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13327/large/400x400_%281%29_%283%29_%282%29.png?1613998208",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "curate"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cyborg Apes",
+      "symbol": "BORG",
+      "address": "CFbdjaKonbBQTYG2GC6CmB7exofgDYGCDR8tp8KVGS7T",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23020/large/lgo-head-export.png?1643094853",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cyborg-apes"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Cykura",
+      "symbol": "CYS",
+      "address": "BRLsMczKuaR5w9vSubF4j8HwEGGprVAyyVgS4EX7DKEg",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18139/large/cyclos-text-logo.png?1630651169",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "cyclos"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DAB Coin",
+      "symbol": "DAB",
+      "address": "32CHtMAuGaCAZx8Rgp54jSFG3ihbpN5brSvRAWpwEHPv",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25275/large/basc-coin.png?1651123747",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dab-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "daoSOL",
+      "symbol": "DAOSOL",
+      "address": "GEJpt3Wjmr628FqXxTgxMce1pLntcPV4uFi8ksxMyPQh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25488/large/logo_%284%29.png?1652071503",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "daosol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Konstellation",
+      "symbol": "DARC",
+      "address": "CpFE715P5DnDoJj9FbCRcuyHHeTXNdRnvzNkHvq1o23U",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2943/large/darctoken.png?1645230834",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "darcmatter-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DarleyGo Essence",
+      "symbol": "DGE",
+      "address": "AAXng5czWLNtTXHdWEn9Ef7kXMXEaraHj2JQKo7ZoLux",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24403/large/DGE.png?1647530006",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "darleygo-essence"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DAWG",
+      "symbol": "DAWG",
+      "address": "3DHPqxdMXogNNnpqBMF8N4Zs4dn1WR31H7UjWq6FExwG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20881/large/143299698-37b637ea-7fce-4bd6-8713-71c42e37629e.png?1637820203",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dawg"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dead Knight",
+      "symbol": "DKM",
+      "address": "HtbhBYdcfXbbD2JiH6jtsTt2m2FXjn7h4k6iXfz98k5W",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24442/large/SAq1GaQc_400x400.jpg?1647673953",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dead-knight"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DEAPCOIN",
+      "symbol": "DEP",
+      "address": "BgwQjVNMWvt2d8CN51CsbniwRWyZ9H9HfHkEsvikeVuZ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/10970/large/DEAPcoin_01.png?1586741677",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "deapcoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Decentraland (Wormhole)",
+      "symbol": "MANA",
+      "address": "7dgHoN8wBZCc5wbnQ2C47TDnBMAxG4Q5L3KjP67z8kNi",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23050/large/MANA_wh_small.png?1644226497",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "decentraland-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DecentSol",
+      "symbol": "DSOL",
+      "address": "5y1YcGVPFy8bEiCJi79kegF9igahmvDe5UrqswFvnpMJ",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/19700/large/QmdvXyoW82LjwF2w3ya2Sr42WQgXzdTo9jfXW452RJXVLD.png?1635752529",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "decentsol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Decimated",
+      "symbol": "DIO",
+      "address": "BiDB55p4G3n1fGhwKFpxsokBMqgctL4qnZpDH1bVQxMD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/8271/large/dio_logo_coloured_transparent.png?1640744585",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "decimated"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DeFi Land",
+      "symbol": "DFL",
+      "address": "DFL1zNkaGPWm1BqAVqRjCZvHmwTFrEaJtbzJWgseoNJh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18910/large/defilend.png?1637190571",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "defi-land"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DeFi Land Gold",
+      "symbol": "GOLDY",
+      "address": "GoLDYyyiVeXnVf9qgoK712N5esm1cCbHEK9aNJFx47Sx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25647/large/GODLY.png?1653025856",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "defi-land-gold"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Degen",
+      "symbol": "DEGN",
+      "address": "A9UhP1xfQHWUhSd54NgKPub2XB3ZuQMdPEvf9aMTHxGT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20103/large/degendex.png?1636512003",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "degen"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Degenerate Ape Academy Floor Index",
+      "symbol": "DAPE",
+      "address": "6AarZpv8KwmPBxBEZdRmd3g1q2tUBaSgTNQ5e621qcZQ",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27054/large/dape.png?1661508642",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "degenerate-ape-academy-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DeltaFi",
+      "symbol": "DELFI",
+      "address": "de1QJkP1qDCk5JYCCXCeq27bQQUdCaiv7xVKFrhPSzF",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24085/large/logo.png?1646293860",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "deltafi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dexlab",
+      "symbol": "DXL",
+      "address": "GsNzxJfFn6zQdJGeYsupJWzUAm57Ba7335mfhWvFiE9Z",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17276/large/3_GradientSymbol.png?1650936792",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dexlab"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dingocoin",
+      "symbol": "DINGO",
+      "address": "6VYF5jXq6rfq4QRgGMG6co7b1Ev1Lj7KSbHBxfQ9e1L3",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/15989/large/dingocoin.png?1634699256",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dingocoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dino",
+      "symbol": "DINO",
+      "address": "6Y7LbYB3tfGBG6CSkyssoxdtHb77AEMTRVXe8JUJRwZ7",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17770/large/solana_dino.png?1629207162",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dino"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DINOEGG",
+      "symbol": "DINOEGG",
+      "address": "2TxM6S3ZozrBHZGHEPh9CtM74a9SVXbr7NQ7UxkRvQij",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22291/large/xOcKL1Fw_400x400.png?1641367958",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dinoegg"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DocuChain",
+      "symbol": "DCCT",
+      "address": "3fXCWpQaEHEsnHSYAqcxm3QLPGLxYiZzoJbqRY9wWxV2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24763/large/zf3Q-GS4_400x400.jpg?1648814553",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "docuchain"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dogelana",
+      "symbol": "DGLN",
+      "address": "E6UU5M1z4CvSAAF99d9wRoXsasWMEXsvHrz3JQRXtm2X",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21133/large/logo_%285%29.png?1642042028",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dogelana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dogelon Mars (Wormhole)",
+      "symbol": "ELON",
+      "address": "6nKUU36URHkewHg5GGGAgxs6szkE4VTioGUT5txQqJFU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23041/large/ELON_wh_small.png?1644225332",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dogelon-mars-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DogemonGo",
+      "symbol": "DOGO",
+      "address": "5LSFpvLDkcdV2a3Kiyzmg5YmJsj2XDLySaXvnfP1cgLT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17480/large/dogemongo.PNG?1627950869",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dogemon-go"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DOGGO",
+      "symbol": "DOGGO",
+      "address": "Doggoyb1uHFJGFdHhJf8FKEBUMv58qo98CisWgeD7Ftk",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28740/large/pllp.jpeg?1673839960",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "doggo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DoggyStyle Coin",
+      "symbol": "DSC",
+      "address": "DogscQVvNVj7ndEnhWiCXPVPKKwNy9fJd4ATF7mVi5J",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20831/large/logo_-_2021-11-24T132426.774.png?1637731476",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "doggystyle-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Drachma Exchange",
+      "symbol": "DRA",
+      "address": "6jAHVBYY2B4dU6hGxXpCqFwHdjDL6aiLtTvJKn8fWRo1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26768/large/Drachma_Exchange_%281%29.png?1660038908",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "drachma-exchange"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Dragon War",
+      "symbol": "DRAW",
+      "address": "48AEwauAHsJibyt3WqjQ6EoHnFBcnyHASfo7vB2eCXPS",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/23100/large/logo_%284%29.png?1643184693",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dragon-war"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Duck Punkz Universe Floor Index",
+      "symbol": "DPUNKZ",
+      "address": "McpgFn2CxFYFq6JLiBxeC6viNfebLsfsf9Sv5wcwKvL",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27171/large/2588.png?1662287086",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "duck-punkz-universe-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "DUST Protocol",
+      "symbol": "DUST",
+      "address": "DUSTawucrTsGU8hcqRdHDCbuYhCPADMLM2VcCb8VnFnQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24289/large/dust-protocol-degod.png?1647306854",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dust-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "dYdX (Wormhole)",
+      "symbol": "DYDX",
+      "address": "4Hx6Bj56eGyw8EJrrheM6LBQAvVYRikYCWsALeTrwyRU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/23039/large/DYDX_wh_small.png?1644225284",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "dydx-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "edeXa Service Token",
+      "symbol": "EDX",
+      "address": "3Ysmnbdddpxv9xK8FUKXexdhRzEA4yrCz8WaE6Za5sjV",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28646/large/EDX_SERVICE_TOKEN.png?1672883345",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "edexa-service-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "EFK Token",
+      "symbol": "EFK",
+      "address": "efk1hwJ3QNV9dc5qJaLyaw9fhrRdjzDTsxbtWXBh1Xu",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27876/large/E_VFDP8f_400x400.jpeg?1666178253",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "efk-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Elumia",
+      "symbol": "ELU",
+      "address": "4tJZhSdGePuMEfZQ3h5LaHjTPsw1iWTRFTojnZcwsAU6",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24433/large/me4oOqTM_400x400.png?1647662654",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "elumia"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Enrex",
+      "symbol": "ENRX",
+      "address": "5s4BYUXLuvs9ZcVDTxkTpKhThWFSpaU8GG55q2iySe2N",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24952/large/enrx.png?1649505778",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "enrex"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Epics Token",
+      "symbol": "EPCT",
+      "address": "CvB1ztJvpYQPvdPBePtRzjL4aQidjydtUz61NWgcgQtP",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28901/large/EpicsCoin200x200.png?1675236360",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "epics-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Equinox",
+      "symbol": "ENX",
+      "address": "87rSGrpYdmTxfNBf8o2cpyiNcxCmNhUPBXjT8aoyfob5",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25234/large/ReKXsCZUnqSChIZZg4dlCIHQTKU0owxPuvj1feBDWaE.png?1650954548",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "equinox"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ethereum (Wormhole)",
+      "symbol": "ETH",
+      "address": "7vfCXTUXx5WJV5JADk17DUJ4ksgau7utNKj4b963voxs",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22990/large/ETH_wh_small.png?1644225466",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ethereum-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Eversol Staked SOL",
+      "symbol": "ESOL",
+      "address": "Hg35Vd8K3BS2pLB3xwC2WqQV8pmpCm3oNRGYP1PEpmCM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23056/large/SUWTLy9j_400x400.jpeg?1657789195",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "eversol-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fabric",
+      "symbol": "FAB",
+      "address": "EdAhkbj5nF9sRM7XN7ewuW8C9XEUMs8P7cnoQ57SYE96",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16649/large/FABLOGO_TRANS200.png?1624592643",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fabric"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Famous Fox Federation",
+      "symbol": "FOXY",
+      "address": "FoXyMu5xwXre7zEoSvzViRk3nGawHUp9kUh97y2NDhcq",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/26191/large/uFYaQEsU_400x400.jpg?1656397523",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "famous-fox-federation"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FaniTrade",
+      "symbol": "FANI",
+      "address": "6c4L5nTH2sBKkfeuP3WhGp6Vq1tE4Suh4ezRp5KSu8Z7",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24029/large/fani_200x200.png?1646115606",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fanitrade"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fenix Danjon",
+      "symbol": "DJN",
+      "address": "GnzxEyULVPQYb5F5hxGc8dEGivctVrfr5mtsdp4z5xU2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21134/large/logo.png?1638361975",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fenix-danjon"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Final Frontier",
+      "symbol": "FRNT",
+      "address": "3vHSsV6mgvpa1JVuuDZVB72vYbeUNzW4mBxiBftwzHEA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24120/large/Token_Logo_2_720p.png?1646386860",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "final-frontier"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Flock",
+      "symbol": "FLOCK",
+      "address": "Hq9MuLDvUAWqC29JhqP2CUJP9879LfqNBHyRRREEXwtZ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22775/large/fUNf0Lu.png?1642577185",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "flock"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FLOOF",
+      "symbol": "FLOOF",
+      "address": "3jzdrXXKxwkBk82u2eCWASZLCKoZs1LQTg87HBEAmBJw",
+      "decimals": 1,
+      "logoURI": "https://assets.coingecko.com/coins/images/19810/large/FLOOF_logo_200x200.png?1635917291",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "floof"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fluid USDC",
+      "symbol": "FUSDC",
+      "address": "Ez2zVjw85tZan1ycnJ5PywNNxR6Gm4jbXQtZKyQNu3Lv",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28471/large/fUSDC-200x200.png?1671002126",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fluid-usdc"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fluid USDT",
+      "symbol": "FUSDT",
+      "address": "D5zHHS5tkf9zfGBRPQbDKpUiRAMVK8VvxGwTHP6tP1B8",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28472/large/fUSDT-200x200.png?1671002181",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fluid-usdt"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fone",
+      "symbol": "FONE",
+      "address": "ATZERmcPfopS9vGqw9kxqRj9Bmdi3Z268nHXkGsMa3Pf",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/23390/large/Fl-zRI0g_400x400.jpg?1644115198",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fone"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fossil",
+      "symbol": "FOSSIL",
+      "address": "6xcfmgzPgABAuAfGDhvvLLMfMDur4at7tU7j3NudUviK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22593/large/dtdm7P1W_400x400.jpg?1642144690",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fossil"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fractionalized SMB-2367",
+      "symbol": "DAOJONES",
+      "address": "r8nuuzXCchjtqsmQZVZDPXXq928tuk7KVH479GsKVpy",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/22611/large/daojones.png?1642228974",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fractionalized-smb-2367"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fractionalized WAVE-999",
+      "symbol": "WAV",
+      "address": "4NGNdLiQ1KG8GgqZimKku4WCLdXbNw6UQJvqax3fE6CJ",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/22176/large/IMG-20220101-021048.jpg?1641176801",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fractionalized-wave-999"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fraktionalized THUG 2856",
+      "symbol": "THUG",
+      "address": "7osS84AkAG2TCrUvrE1wfKwfAqWTCrHnaCsrsyVJd5pY",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/22678/large/q4h6GvG6MQfhXXNJTbLILbZY1OIgLqkJNHzNLClHDiw.png?1642406678",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fraktionalized-thug-2856"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FRAKT",
+      "symbol": "FRKT",
+      "address": "ErGB9xa24Szxbk1M28u2Tx8rKPqzL6BroNkkzk5rG4zj",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/18926/large/logo_-_2021-10-11T132203.751.png?1633929748",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "frakt-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Frax",
+      "symbol": "FRAX",
+      "address": "FR87nWEUxVgerFGhZM8Y4AggKGLnaXswr1Pd8wZ4kZcp",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13422/large/ethCanonicalFRAX.png?1669277108",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "frax"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Frax Share",
+      "symbol": "FXS",
+      "address": "6LX8BhMQ4Sy2otmAWj7Y5sKd9YTVVUgfMsBzT6B9W7ct",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13423/large/ethCanonicalFXS.png?1669276861",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "frax-share"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fronk",
+      "symbol": "FRONK",
+      "address": "5yxNbU8DgYJZNi3mPD9rs4XLh9ckXrhPjJ5VCujUWg5H",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28679/large/_7XVXQ46_400x400.jpg?1673340405",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fronk"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FTX",
+      "symbol": "FTT",
+      "address": "AGFEad2et2ZJif9jaGpdMixQqvW5i81aBdvKe7PHNfz3",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/9026/large/F.png?1609051564",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ftx-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FTX (Wormhole)",
+      "symbol": "FTT",
+      "address": "EzfgjvkSwthhgHaceR3LnKXUoRkP6NUhfghdaHAj1tUv",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22996/large/FTT_wh_small.png?1644225637",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ftx-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Fuji",
+      "symbol": "FUJI",
+      "address": "fujiCeCeP9AFDVCv27P5JRcKLoH7wfs2C9xmDECs24m",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/23732/large/vopR7PC.png?1645171161",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fuji"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "FUMoney",
+      "symbol": "FUM",
+      "address": "EZF2sPJRe26e8iyXaCrmEefrGVBkqqNGv9UPGG9EnTQz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21054/large/KuH9TXMM_400x400.jpg?1638263205",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "fumoney"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Future",
+      "symbol": "FTR",
+      "address": "HEhMLvpSdPviukafKwVN8BnBUTamirptsQ6Wxo5Cyv8s",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17316/large/logo_-_2021-07-26T164152.450.png?1627288961",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "future"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Galaxy Essential",
+      "symbol": "GXE",
+      "address": "DsVPH4mAppxKrmdzcizGfPtLYEBAkQGK4eUch32wgaHY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25754/large/GXE.png?1653466290",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "galaxy-essential"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Galaxy War",
+      "symbol": "GWT",
+      "address": "GWTipxSJVPmmW2wCjBdkbnEJbCRCyrhL2x9zuHRPPTj1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22166/large/e2x7gMJ4_400x400.jpg?1641166277",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "galaxy-war"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GameYoo",
+      "symbol": "GYC",
+      "address": "GYCVdmDthkf3jSz5ns6fkzCmHub7FSZxjVCfbfGqkH7P",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24525/large/gameyoo-logo-200x200.png?1648027227",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gameyoo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Gari Network",
+      "symbol": "GARI",
+      "address": "CKaKtYvz6dKPyMvYq9Rh3UBrnNqYZAyd7iF4hJtjUvks",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22615/large/gari.png?1642313087",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gari-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Garlic",
+      "symbol": "GRLC",
+      "address": "88YqDBWxYhhwPbExF966EdaCYBKP51xVm1oGBcbWzcf2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21011/large/logo.png?1638190406",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "garlic"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Gary",
+      "symbol": "GARY",
+      "address": "8c71AvjQeKKeWRe8jtTGG1bJ2WiYXQdbjqFbUfhHgSVk",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26448/large/gary_logo_icon.png?1658111709",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gary"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Gear",
+      "symbol": "GEAR",
+      "address": "7s6NLX42eURZfpyuKkVLrr9ED9hJE8718cyXFsYKqq5g",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24653/large/output-onlinepngtools.png?1648524609",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gear"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shadow Token",
+      "symbol": "SHDW",
+      "address": "SHDWyBxihqiCj6YekG2GUr7wqKLeLAMK1gHZck9pL6y",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22271/large/Property_1_Color.png?1666926988",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "genesysgo-shadow"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Genopets KI",
+      "symbol": "KI",
+      "address": "kiGenopAScF8VF31Zbtx2Hg8qA5ArGqvnVtXb83sotc",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26135/large/genopets_ki.png?1660017469",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "genopet-ki"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Genopets",
+      "symbol": "GENE",
+      "address": "GENEtH5amGSi8kHAtQoezp1XEXwZJ8vcuePYnXdKrMYz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20360/large/gene-token.png?1636945172",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "genopets"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GENZ Token",
+      "symbol": "GENZ",
+      "address": "GENZexWRRGNS2Ko5rEgGG1snRXpaa3CDDGYnhTSmE3kd",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28039/large/Qq_rj-aG_400x400.png?1667199323",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "genz-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GhostKids",
+      "symbol": "BOO",
+      "address": "boooCKXQn9YTK2aqN5pWftQeb9TH7cj7iUKuVCShWQx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28814/large/logo-BOO.png?1674455732",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ghostkids"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Glitter Finance",
+      "symbol": "XGLI",
+      "address": "FsPncBfeDV3Uv9g6yyx1NnKidvUeCaAiT2NtBAPy17xg",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23292/large/glitter_finance.png?1660285639",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "glitter-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GMSOL",
+      "symbol": "GMSOL",
+      "address": "gmdu3snwW28DmmxCseChp9owWLUhamH9eS3hWfHG8Vg",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20717/large/gm-logo-200.png?1637584967",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gmsol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GNAR",
+      "symbol": "GNAR",
+      "address": "74YedyBSKbjYzWMhwuBQz3mwsN6vuSSdAfzX9WLZQUtq",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/21534/large/hL60Xh2.png?1639400726",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gnar-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GOATS",
+      "symbol": "GOATS",
+      "address": "DVPWKGLFHK73PwgKgTtW28iCZGewQdva2N5HeBLDorVJ",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/22109/large/logo_200x200.png?1640841012",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "goats"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Gobi Labs",
+      "symbol": "GOBI",
+      "address": "MarcoPaG4dV4qit3ZPGPFm4qt4KKNBKvAsm2rPGNF72",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28554/large/GOBI.png?1671697657",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gobi-labs"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GooseFX",
+      "symbol": "GOFX",
+      "address": "GFX1ZjR2P15tmrSwow6FjyDYcEkoFb4p4gJCpLBjaxHD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19793/large/0Kjm9f4.png?1635906737",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "goosefx"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Grape Protocol",
+      "symbol": "GRAPE",
+      "address": "8upjSpvjcdpuzhfR1zriwg5NXkwDruejqNE9WNbPRtyA",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18149/large/fRsuAlcV_400x400.png?1632437325",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "grape-2"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "STEPN Green Satoshi Token on Solana",
+      "symbol": "GST-SOL",
+      "address": "AFbX8oGjGpmVFywbVouvhQSRmiW2aR1mohfahi4Y2AdB",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21841/large/gst.png?1640332626",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "green-satoshi-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "GTON CAPITAL",
+      "symbol": "GTON",
+      "address": "nVZnRKdr3pmcgnJvYDE8iafgiMiBqxiffQMcyv5ETdA",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/15728/large/GC_logo_200x200.png?1642669327",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gton-capital"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kugle GU",
+      "symbol": "GU",
+      "address": "5KV2W2XPdSo97wQWcuAVi6G4PaCoieg4Lhhi61PAMaMJ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17532/large/Logo_GU_512.png?1628129442",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "gu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hades",
+      "symbol": "HADES",
+      "address": "BWXrrYFhT7bMHmNBFoQFWdsSgA3yXoAnMhDK6Fn1eSEn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28819/large/hadeswap.jpeg?1674624974",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hades"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "HAPI",
+      "symbol": "HAPI",
+      "address": "6VNKqgz9hk7zRShTFdg5AnkfKwZUcojzwAkzxSH3bnUm",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14298/large/R9i2HjAL_400x400.jpg?1615332438",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hapi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hawksight",
+      "symbol": "HAWK",
+      "address": "BKipkearSqAUdNKa1WDstvcMjoPsSKBuNyvKDQDDu9WE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24459/large/3CnlKM0x_400x400.jpg?1647679676",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hawksight"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Heavenland HTO",
+      "symbol": "HTO",
+      "address": "htoHLBJV1err8xP5oxyQdV2PLQhtVjxLXpKB7FsgJQD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25553/large/rTFh6BD.png?1652420842",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "heavenland-hto"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hedge Protocol",
+      "symbol": "HDG",
+      "address": "5PmpMzWjraf3kSsGEKtqdUsCoLhptg4yriZ17LKKdBBy",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25482/large/hdg.png?1652011201",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hedge-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hedge USD",
+      "symbol": "USH",
+      "address": "9iLH8T7zoWhY7sBmj1WK9ENbWdS1nL8n9wAxaeRitTa6",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25481/large/ush.png?1652011029",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hedge-usd"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "High Roller Hippo Clique",
+      "symbol": "ROLL",
+      "address": "76aYNHbDfHemxSS7vmh6eJGfjodK8m7srCxiYCrKxzY1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23458/large/OslGsgzd_400x400.jpg?1644215478",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "high-roller-hippo-clique"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Himalayan Cat Coin",
+      "symbol": "HIMA",
+      "address": "72hgmvS5zFxaFJfMizq6Gp4gjBqXjTPyX9GDP38krorQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19970/large/hima.png?1636344984",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "himalayan-cat-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hippo Coin",
+      "symbol": "$HIPPO",
+      "address": "3EkHyexJLGCvSxzn5umbtd9N69GoT4p5pfdLTFqCNP9Y",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20728/large/iu-n3i1b_400x400.jpg?1637596901",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hippo-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hiram",
+      "symbol": "HIRAM",
+      "address": "GDsVXtyt2CBwieKSYMEsjjZXXvqz2G2VwudD7EvXzoEU",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/23457/large/logo_%281%29.png?1644215352",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hiram"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "HolyGrails.io",
+      "symbol": "HOLY",
+      "address": "HezGWsxSVMqEZy7HJf7TtXzQRLiDruYsheYWqoUVnWQo",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28395/large/HG_Token_Design-07.png?1670290228",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "holygrails-io"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Honey Finance",
+      "symbol": "HONEY",
+      "address": "HonyeYAaTPgKUgQpayL914P6VAqbQZPrbkGMETZvW4iN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24781/large/honey.png?1648902423",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "honey-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hono",
+      "symbol": "HONO",
+      "address": "BGN9c9JJxMgmm7rUqeLanYwWwo2GbedjUFaXn7tAeuXK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21870/large/hono.png?1640180863",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hono"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hubble",
+      "symbol": "HBB",
+      "address": "HBB111SCo9jkCejsZfz8Ec8nH7T6THF8KEKSnvwT6XK6",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22070/large/hubble.PNG?1640749942",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hubble"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hunter Diamond",
+      "symbol": "HUNT",
+      "address": "CTYiHf58UGShfHtpkTwx7vjPDA779dd6iVaeD281fEVx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27566/large/Token_Hunters__CoinMarketCap.png?1664522159",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hunter-diamond"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Hxro",
+      "symbol": "HXRO",
+      "address": "HxhWkVpk5NS4Ltg5nij2G671CKXFRKPK8vy271Ub4uEK",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/7805/large/Hxro_Profile_Transparent.png?1622443308",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "hxro"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Intersola",
+      "symbol": "ISOLA",
+      "address": "333iHoRM2Awhf9uVZtSyTfU8AekdGrgQePZsKMFPgKmS",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17460/large/IS_token_icon3.png?1627883249",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "intersola"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Investin",
+      "symbol": "IVN",
+      "address": "iVNcrNE9BRZBC9Aqf753iZiZfbszeAVUoikgT9yvr2a",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15588/large/ivn_logo.png?1621267247",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "investin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Invictus",
+      "symbol": "IN",
+      "address": "inL8PMVd6iiW3RCBJnr5AsrRN6nqr4BTrcNuQWQSkvY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20097/large/jv2xoOxJ_400x400.jpg?1636494713",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "invictus"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Invoker",
+      "symbol": "IV",
+      "address": "invSTFnhB1779dyku9vKSmGPxeBNKhdf7ZfGL1vTH3u",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23396/large/inv.png?1644132833",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "invoke"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Jelly eSports",
+      "symbol": "JELLY",
+      "address": "9WMwGcY6TcbSfy9XPpQymY3qNEsvEaYL3wivdwPG2fpp",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28572/large/jellylogo.png?1671863817",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jelly-esports"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "JET",
+      "symbol": "JET",
+      "address": "JET6zMJWkCN9tpRT2v2jfAmm5VnQFDpUBCyaKojmGtz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18437/large/jet_logomark_color.png?1631972990",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jet"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Jito Staked SOL",
+      "symbol": "JITOSOL",
+      "address": "J1toso1uCk3RLmjorhTtrVwY9HJ7X8V9yYac6Y7kGCPn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28046/large/JitoSOL-200.png?1667271467",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jito-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Jokes Meme",
+      "symbol": "JOKE",
+      "address": "8NGgmXzBzhsXz46pTC3ioSBxeE3w2EXpc741N3EQ8E6r",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16719/large/newjoketoken.png?1624845136",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jokes-meme"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "JPool",
+      "symbol": "JSOL",
+      "address": "7Q2afV64in6N6SeZsAAB81TJzwDoD6zpqmHkzi9Dcavn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20664/large/jsol.png?1637545897",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jpool"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Jungle",
+      "symbol": "JUNGLE",
+      "address": "Aogv6j1wWiBAZcqRNN1Y89eozda2ke6rkc4CYy7c4iCi",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20893/large/O9Usopi.png?1637847516",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jungle"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Jungle DeFi",
+      "symbol": "JFI",
+      "address": "GePFQaZKHcWE5vpxHfviQtH5jgxokSs51Y5Q4zgBiMDs",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23679/large/logo.png?1644997055",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "jungle-defi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kaizen",
+      "symbol": "KZEN",
+      "address": "kZEn3aDxEzcFADPe2VQ6WcJRbS1hVGjUcgCw4HiuYSU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24396/large/PKl5OVRv_400x400.png?1647522756",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kaizen"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kalisten",
+      "symbol": "KS",
+      "address": "3swraHsc77KMg1tFvwH3tfYcd8SWr5fcUhtmRxjavG7H",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25486/large/kalisten_token.png?1652067781",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kalisten"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Keeshond",
+      "symbol": "$KSH",
+      "address": "6j14WyX1Ag2pLWvn99euK4xp2VcZD62VeJv2iwCrYmT8",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21353/large/lkdYjrVS_400x400.jpg?1638999576",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "keeshond"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kekwcoin",
+      "symbol": "KEKW",
+      "address": "2QK9vxydd7WoDwvVFT5JSU8cwE9xmbJSzeqbRESiPGMG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18311/large/logo_black_%281%29.png?1631509612",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kekwcoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kermit Finance",
+      "symbol": "KERMIT",
+      "address": "7xzovRepzLvXbbpVZLYKzEBhCNgStEv1xpDqf1rMFFKX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17109/large/NFhvfXh.png?1626615453",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kermit"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "KillSwitch",
+      "symbol": "KSW",
+      "address": "8ymjMjitLchSFU9zkcbjsJENhSXou4YKh7RD2U3yvqdJ",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/20215/large/logo_%2824%29.png?1636670633",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "killswitch"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kin",
+      "symbol": "KIN",
+      "address": "kinXdEcpDQeHPEuQnqmUgtYykqKGVFq6CeVX5iAHJq6",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/959/large/kin-circle-white.png?1669864374",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "KKO Protocol",
+      "symbol": "KKO",
+      "address": "kiNeKo77w1WBEzFFCXrTDRWGRWGP8yHvKC9rX6dqjQh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15366/large/kko-coingecko.png?1658982821",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kineko"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kineko",
+      "symbol": "KNK",
+      "address": "kNkT1RDnexWqYP3EYGyWv5ZtazB8CfgGAfJtv9AQ3kz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26597/large/knk-cmc-logo.png?1658974690",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kineko-knk"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "King Samo",
+      "symbol": "KSAMO",
+      "address": "HDiA4quoMibAGeJQzvxajp3Z9cvnkNng99oVrnuNj6px",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21237/large/KSAMO_1.png?1638759919",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "king-samo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kitty Coin Solana",
+      "symbol": "KITTY",
+      "address": "6XWfkyg5mzGtKNftSDgYjyoPyUsLRf2rafj95XSFSFrr",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20819/large/brand-1.png?1642645998",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kitty-coin-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kitty Solana",
+      "symbol": "KITTY",
+      "address": "6JdcMdhqgCtcP4U9tieRqmKLhPLxRMLC67QfmdXAJBvZ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20313/large/kittysolanalogo-1.jpg?1636844407",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kitty-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Krill",
+      "symbol": "KRILL",
+      "address": "EP2aYBDD4WvdhnwWLUMyqU69g1ePtEjgYK6qyEAFCHTx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23917/large/Krill_towen.png?1645684293",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "krill"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Krook Coin",
+      "symbol": "KROOK",
+      "address": "AfARcLLqRHsZc4xPWHE9nXZAswZaW294Ff1xcYQbjkLq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22160/large/143821720-d9c6f5fd-96d7-424f-9b1f-b185451cbb31.png?1640949570",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "krook-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "KROWN",
+      "symbol": "KRW",
+      "address": "Gw7M5dqZJ6B6a8dYkDry6z9t9FuUA2xPUokjV2cortoq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16530/large/KRW_token_logo_200x200.png?1624343058",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "krown"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Kurobi",
+      "symbol": "KURO",
+      "address": "2Kc38rfQ49DFaKHQaWbijkE7fcymUMLY5guUiUsDmFfn",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18612/large/logo_-_2021-09-26T233232.947.png?1632670367",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "kurobi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "LABS Protocol",
+      "symbol": "LABS",
+      "address": "LABSfApdYpC5Ek1tQiCFAoQP5K8CvADe2GgdYrA2QHh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26913/large/monsta-scientist.jpg?1660787720",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "labs-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "LadderCaster",
+      "symbol": "LADA",
+      "address": "95bzgMCtKw2dwaWufV9iZyu64DQo1eqw6QWnFMUSnsuF",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25108/large/Logo_Small_Resized.png?1650533759",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "laddercaster"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Laine Stake",
+      "symbol": "LAINESOL",
+      "address": "LAinEtNLgpmCP9Rvsf5Hn8W6EhNiKLZQti1xfWMLy6X",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28184/large/laineSOL.png?1668257050",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "laine-stake"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Lambda Markets",
+      "symbol": "LMDA",
+      "address": "LMDAmLNduiDmSiMxgae1gW7ubArfEGdAfTpKohqE5gn",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/28653/large/XFAIIV1f_400x400.jpg?1672896515",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lambda-markets"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Larix",
+      "symbol": "LARIX",
+      "address": "Lrxqnh6ZHKbGy3dcrCED43nsoLkM1LTzU2jRfWe8qUC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18450/large/larix.PNG?1632092483",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "larix"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Learning Star",
+      "symbol": "LSTAR",
+      "address": "C6qep3y7tCZUJYDXHiwuK46Gt6FsoxLi8qV1bTCRYaY1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25986/large/20581.png?1655155804",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "learning-star"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Legends Of Aria",
+      "symbol": "ARIA",
+      "address": "F4q5mMxk9RA2a9dwfa2FgJjhvuqbk8SC9jEpnDVz5TFy",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27157/large/ARIA_LOGO.png?1662276215",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "legends-of-aria"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Leonidas Token",
+      "symbol": "LEONIDAS",
+      "address": "7puG5H5Mc6QpvaXjAVLr6GnL5hhUMnpLcUm8G3mEsgHQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20496/large/cropped-logo_%281%29.png?1637131887",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "leonidas-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Lido DAO (Wormhole)",
+      "symbol": "LDO",
+      "address": "HZRCwxP2Vq9PCpPXooayhJ2bxTpo5xfpQrwB1svh332p",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22995/large/LDO_wh_small.png?1644226233",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lido-dao-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Lido Staked SOL",
+      "symbol": "STSOL",
+      "address": "7dHbWXmci3dT8UFYWYZweBLXgycu7Y3iL6trKn1Y7ARj",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18369/large/logo_-_2021-09-15T100934.765.png?1631671781",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lido-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Lifinity",
+      "symbol": "LFNTY",
+      "address": "LFNTYraetVioAPnGJht4yNg2aUZFXR776cMeN9VMjXp",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25406/large/LFNTY_s.png?1651731251",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lifinity"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "LIQ Protocol",
+      "symbol": "LIQ",
+      "address": "4wjPQJ6PrkC4dHhYghwJzGBVP78DkBzA2U3kHoFNBuhj",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/16534/large/85853665.png?1624348565",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "liq-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "LittleInu",
+      "symbol": "LINU",
+      "address": "41TwwURtuv4k8TuFxp1vfFYP9noMbHXqtscse8xLM26V",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22029/large/unknown_%281%29.png?1640657606",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "littleinu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Lizard",
+      "symbol": "LIZARD",
+      "address": "5ENUvV3Ur3o3Fg6LVRfHL4sowidiVTMHHsEFqNJXRz6o",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/19892/large/lizard_logo_3-ts1636074175.jpg?1636093462",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lizard-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Loot",
+      "symbol": "LOOT",
+      "address": "GzpRsvnKXKz586kRLkjdppR4dUCFwHa2qaszKkPUQx6g",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23015/large/Bag_Open_%283%29.png?1643093342",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "loot-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "LP Finance DAO",
+      "symbol": "LPFI",
+      "address": "LPFiNAybMobY5oHfYVdy9jPozFBGKpPiEGoobK2xCe3",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27704/large/output-onlinepngtools_%2827%29.png?1666087863",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "lp-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Terra Classic (Wormhole)",
+      "symbol": "LUNC",
+      "address": "F6v4wfAdJB8D8p77bMXZgYt8TDKsYxLYxH5AFhUkYx9W",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22951/large/LUNA_wh_small.png?1644226405",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "luna-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Magic Eggs",
+      "symbol": "MAGA",
+      "address": "Ma4dse7fmzXLQYymNsDDjq6VgRXtEFTJw1CvmRrBoKN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24843/large/Maga-200x200.png?1649107298",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "magic-eggs"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Maneki-neko",
+      "symbol": "NEKI",
+      "address": "ALKiRVrfLgzeAV2mCT7cJHKg3ZoPvsCRSV7VCRWnE8zQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21321/large/logo.png?1638944515",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "maneki-neko"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mango",
+      "symbol": "MNGO",
+      "address": "MangoCzJ36AjZyKwVj3VnYU4GTonjfVEnJmvvWaxLac",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14773/large/token-mango.png?1628171237",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mango-markets"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MAPS",
+      "symbol": "MAPS",
+      "address": "MAPS41MDahZ9QdKXhVa4dWB9RuyfV4XqhyAZ8XcYepb",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/13556/large/Copy_of_image_%28139%29.png?1609768934",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "maps"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Marinade",
+      "symbol": "MNDE",
+      "address": "MNDEFzGvMt87ueuHvVU9VcTqsAP5b3fTGPsHuuPA5ey",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18867/large/MNDE.png?1643187748",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "marinade"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MATIC (Wormhole)",
+      "symbol": "MATICPO",
+      "address": "Gz7VkD4MacbEB6yC5XD3HcumEiYx2EtDYYrfikGsvopG",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22947/large/MATICpo_wh_small.png?1644226625",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "matic-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MatrixETF",
+      "symbol": "MDF",
+      "address": "ALQ9KMWjFmxVbew3vMkJj3ypbAKuorSgGst6svCHEe2z",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18538/large/MDF.png?1632304949",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "matrixetf"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Matrix Solana Index",
+      "symbol": "MSI",
+      "address": "2e7yNwrmTgXp9ABUmcPXvFJTSrEVLj4YMyrb4GUM4Pdd",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20785/large/MSI.png?1637671199",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "matrix-solana-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mean DAO",
+      "symbol": "MEAN",
+      "address": "MEANeD3XDdUmNMsRGjASkSWdC8prLYsoRJ61pPeHctD",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21557/large/89934951.png?1639466364",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "meanfi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Media Network",
+      "symbol": "MEDIA",
+      "address": "ETAtLmCmsoiEEKfNrHKJ2kYy3MoABhU6NQvpSfij5tDs",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15142/large/media50x50.png?1620122020",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "media-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MekkaCoin",
+      "symbol": "MEK",
+      "address": "MekkANZkBpzbGeTWsD1cRRuQxZMTFfBJyLrKywGQRss",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27530/large/unknown_%2819%29.png?1664372136",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mekkacoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MekkaFroggo",
+      "symbol": "MEKKA",
+      "address": "6YAXGyWb3hhLVQQ3vqg9ZYewXk4Cknnr1raTfDwbf8XG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24118/large/k_9e4luFsOmMVOGhBqxBb6we5HkKFE_NwNza--t7MAk.png?1646381909",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mekkafroggo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mekka Froggo",
+      "symbol": "LFGO",
+      "address": "7z1eQmEhhM9e1AVCBQc6BzMZWmCZRqHCLJtkDgHxzYnQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22244/large/LK5s4mx-d5GIPPPmilZLRBtxH0OvOAp02sbgYCbFRtE.png?1641275800",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mekka-froggo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mend",
+      "symbol": "MEND",
+      "address": "Ch9NFVk5sqEPQHtw2gJVgnHfTm7FW1JspYwc7SxLi6q3",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25917/large/logo-e1637099222337.png?1654592434",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mend"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mercurial",
+      "symbol": "MER",
+      "address": "MERt85fc5boKw3BW1eYdxonEuJNvXbiMbs6hvheau5K",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15527/large/mer_logo.png?1621128922",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mercurial"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Metacraft Mineral",
+      "symbol": "MEMI",
+      "address": "ATEMTyZVC1yDHYUg1aqHC6cpn8KVLe4Bbn7G74xSRDqG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27214/large/Metacraft_Mineral_MEMI_icon_200x200px.png?1662610576",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metacraft-mineral"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MetaMall",
+      "symbol": "MALL",
+      "address": "5EbpXhW7t8ypBF3Q1X7odFaHjuh7XJfCohXR3VYAW32i",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/24183/large/gRlsG1JA_400x400.jpg?1646787127",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metamall"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MetaMounts",
+      "symbol": "MOUNT",
+      "address": "9QXAu7FTf7hmswBQwKxvuqGgWH42FyQjqXJanUt6y4eC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21578/large/download_%2845%29.png?1639530542",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metamounts"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Metaplex",
+      "symbol": "MPLX",
+      "address": "METAewgxyPbgwsseH8T16a39CQ5VyVxZi9zXiDPY18m",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27344/large/mplx.png?1663636769",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metaplex"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MetaShells",
+      "symbol": "SHELL",
+      "address": "BRg8CLYEStYAFQad3CVMCYy1cgeuvUnarAZLV8K8Hyfv",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23230/large/metashellslogo.png?1643355563",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metashells"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MetaToken",
+      "symbol": "MTK",
+      "address": "ANXqXpSkTEuCnR27YK2AoHNH2CCbiSaKYAKcDQVMi6ar",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28053/large/metatoken_icon.png?1667286996",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "metatoken"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Million Monke",
+      "symbol": "MIMO",
+      "address": "9TE7ebz1dsFo1uQ2T4oYAKSm39Y6fWuHrd6Uk6XaiD16",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21071/large/200xMIMO.png?1638281151",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "million-monke"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MILLIONSY",
+      "symbol": "MILLI",
+      "address": "HDLRMKW1FDz2q5Zg778CZx26UgrtnqpUDkNNJHhmVUFr",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20396/large/Logo_200px_%281%29.png?1641567027",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "millionsy"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MIM",
+      "symbol": "SWARM",
+      "address": "4dydh8EGNEdTz6grqnGBxpduRg55eLnwNZXoNZJetadu",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19927/large/13988.png?1636323160",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mim"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MAI",
+      "symbol": "MIMATIC",
+      "address": "9mWRABuz2x6koTPCWiCPM49WUbcrNqGTHBV9T9k7y1o7",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15264/large/mimatic-red.png?1620281018",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mimatic"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Mindfolk Wood",
+      "symbol": "$WOOD",
+      "address": "674PmuiDtgKx3uKuJ1B16f9m5L84eFvNwj3xDMvHcbo7",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22512/large/tokenlogo.png?1641966072",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mindfolk-wood"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MMA Gaming",
+      "symbol": "MMA",
+      "address": "MMAx26JtJgSWv6yH48nEHCGZcVvRbf9Lt9ALa7jSipe",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23767/large/18166.png?1645425116",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mma-gaming"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MongooseCoin",
+      "symbol": "MONGOOSE",
+      "address": "J7WYVzFNynk9D28eBCccw2EYkygygiLDCVCabV7CupWL",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21513/large/logo_mong.png?1639375760",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "mongoosecoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MonkeyLeague",
+      "symbol": "MBS",
+      "address": "Fm9rHUTF5v3hwMLbStjZXqNBBoZyGriQaFM6sTFz3K8A",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20841/large/monkeyball.png?1639023123",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "monkeyball"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MoonLana",
+      "symbol": "MOLA",
+      "address": "AMdnw9H5DFtQwZowVFr4kUgSXJzLokKSinvgGiUoLSps",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16278/large/NW8RySX.png?1623635238",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "moonlana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Moshiheads",
+      "symbol": "MOSHI",
+      "address": "MoshMwLkVu4iwrPBaWpYkh43qJiSXsnyzNLuMXFv5F4",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24940/large/token.png?1649423230",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "moshiheads"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Marinade staked SOL",
+      "symbol": "MSOL",
+      "address": "mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17752/large/mSOL.png?1644541955",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "msol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Musk Doge",
+      "symbol": "MKD",
+      "address": "FatneQg39zhrG6XdwYb8fzM4VgybpgqjisJYESSBD7FV",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22317/large/20211215_125931.jpg?1641453649",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "musk-doge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Naga Kingdom",
+      "symbol": "NAGA",
+      "address": "NaFJTgvemQFfTTGAq2PR1uBny3NENWMur5k6eBsG5ii",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24895/large/Naga-200x200.png?1649304588",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "naga-kingdom"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Naxar",
+      "symbol": "NAXAR",
+      "address": "Fp4gjLpTsPqBN6xDGpDHwtnuEofjyiZKxxZxzvJnjxV6",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/16946/large/logo.png?1655886562",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "naxar"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Neonomad Finance",
+      "symbol": "NNI",
+      "address": "buMnhMd5xSyXBssTQo15jouu8VhuEZJCfbtBUZgRcuW",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25068/large/SeSkZxx7_400x400.jpeg?1658118217",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "neonomad-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nest Arcade",
+      "symbol": "NESTA",
+      "address": "Czt7Fc4dz6BpLh2vKiSYyotNK2uPPDhvbWrrLeD9QxhV",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24182/large/mPFhh9sZ_400x400.jpg?1646786783",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nest-arcade"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "NeXt-DeFi Protocol",
+      "symbol": "NXDF",
+      "address": "Au6EdrSDubCUc34awy9c6iQAg5GSos9pPBXyZQtyZewV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22783/large/NXDF.png?1642579165",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "next-defi-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "NftEyez",
+      "symbol": "EYE",
+      "address": "G7eETAaUzmsBPKhokZyfbaT4tD9igdZSmfQGEYWem8Sw",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22079/large/eye-coin.png?1640755291",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nfteyez"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ninja Protocol",
+      "symbol": "NINJA",
+      "address": "FgX1WD9WzMU3yLwXaFSarPfkgzjLb2DZCqmkx9ExpuvJ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18442/large/ninja.PNG?1632006127",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ninja-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nirvana ANA",
+      "symbol": "ANA",
+      "address": "ANAxByE6G2WjFp7A4NqtWYXb3mgruyzZYg3spfxe6Lbo",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25012/large/ANA_Logo.png?1649822203",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nirvana-ana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nirvana NIRV",
+      "symbol": "NIRV",
+      "address": "NRVwhjBQiUPYtfDT5zRBVJajzFQHaBUNtC7SNVvqRFa",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25050/large/NIRV.png?1649915345",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nirvana-nirv"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nirvana prANA",
+      "symbol": "PRANA",
+      "address": "PRAxfbouRoJ9yZqhyejEAH6RvjJ86Y82vfiZTBSM3xG",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26176/large/prANA.png?1656379283",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nirvana-prana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "NodeBunch",
+      "symbol": "NOCH",
+      "address": "EcFyPDjqpnyMvh1LhACtC6rrCZ41DMez7RZYocjhmUVS",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24880/large/logo.png?1649224634",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nodebunch"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "NoGoal",
+      "symbol": "INO",
+      "address": "E1PvPRPQvZNivZbXRL61AEGr71npZQ5JGxh4aWX7q9QA",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19650/large/ino-512.png?1635732061",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nogoaltoken"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "NPC DAO",
+      "symbol": "NPC",
+      "address": "EuD5L5XSYKzyDC1YyYzmoWC8gmJhpEh2vMj4f8LeRW8r",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19981/large/1EXEFTo6_400x400.jpg?1640251890",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nole-npc"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nora",
+      "symbol": "NRA",
+      "address": "1C2EYVrwmoXAGbiKirFFBeDFDYUBHPhDeg9trhibTND",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20107/large/NORA.png?1644222708",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nora-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nosana",
+      "symbol": "NOS",
+      "address": "nosXBVoaCTtYdLvKY6Csb4AC8JCdQKKAaWYtx2ZMoo7",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22553/large/POfb_I4u_400x400.jpg?1642053655",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nosana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Nova Finance",
+      "symbol": "NOVA",
+      "address": "BDrL8huis6S5tpmozaAaT5zhE5A7ZBAB2jMMvpKEeF8A",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21672/large/bGVB8h2Q_400x400.jpg?1639710371",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "nova-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "oDOP",
+      "symbol": "ODOP",
+      "address": "4pk3pf9nJDN1im1kNwWJN1ThjE8pCYCTexXYGyFjqKVf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15781/large/odop.PNG?1621843047",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "odop"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Okami Lana",
+      "symbol": "OKANA",
+      "address": "okaxuoDnpewHyCoYykiNX4pmJwKodhWxVxb2tCuGxMy",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28754/large/OkamiLana_Logo_Update.png?1674307623",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "okami-lana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Okay Bears Floor Index",
+      "symbol": "OKAYB",
+      "address": "Ca9LxRYdZ7jK4QAqjLo4iaYmiV8FNdngtSkzM69hzgDX",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/27170/large/9815.png?1662286926",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "okay-bears-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Onespace",
+      "symbol": "1SP",
+      "address": "2zzC22UBgJGCYPdFyo7GDwz7YHq5SozJc1nnBqLU8oZb",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26474/large/1SP_logo.png?1658195640",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "onespace"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Only1",
+      "symbol": "LIKE",
+      "address": "3bRTivrVsitbmCTGtqwp7hxXPsybkjn4XLNtPsHqa3zR",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17501/large/like-token.png?1628036165",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "only1"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "OOGI",
+      "symbol": "OOGI",
+      "address": "H7Qc9APCWWGDVxGD5fJHmLTmdEgT9GFatAKFNg6sHh8A",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19714/large/oogi.PNG?1635756218",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "oogi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "OPPA",
+      "symbol": "OPPA",
+      "address": "9K4uNquZjVSBBN6fBsp62gtYLropyAxAbdZC7D9XErih",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20359/large/oppa.png?1636945164",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "oppa"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Orca",
+      "symbol": "ORCA",
+      "address": "orcaEKTdK7LKz57vaAYr9QeNsVEPfiu6QeMU1kektZE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17547/large/Orca_Logo.png?1628781615",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "orca"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Otter Finance",
+      "symbol": "OTR",
+      "address": "6TgvYd7eApfcZ7K5Mur7MaUQ2xT7THB4cLHWuMkQdU5Z",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20157/large/VAPiUujl_400x400.png?1636590602",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "otter-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Oxbull Solana",
+      "symbol": "OXS",
+      "address": "4TGxgCSJQx2GQk9oHZ8dC5m3JNXTYZHjXumKAW3vLnNx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17304/large/9xPPXxJC_400x400.jpg?1627269668",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "oxbull-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Oxygen",
+      "symbol": "OXY",
+      "address": "z3dn17yLaGMKffVogeFHQ9zWVcXgqgf3PQnDsNs2g6M",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/13509/large/8DjBZ79V_400x400.jpg?1609236331",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "oxygen"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Panda Coin",
+      "symbol": "PANDA",
+      "address": "Aw8qLRHGhMcKq7rxs5XBNCd9oe3BvoAhpNMVz7AdGmty",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20500/large/panda.png?1638349709",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "panda-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Parasol Finance",
+      "symbol": "PSOL",
+      "address": "Hmatmu1ktLbobSvim94mfpZmjL5iiyoM1zidtXJRAdLZ",
+      "decimals": 7,
+      "logoURI": "https://assets.coingecko.com/coins/images/21551/large/icon.png?1642584584",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "parasol-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Parrot Protocol",
+      "symbol": "PRT",
+      "address": "PRT88RkA4Kg5z7pKnezeNH4mafTvtQdfFgpQTGRjz44",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18443/large/PRT.png?1634698095",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "parrot-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Parrot USD",
+      "symbol": "PAI",
+      "address": "Ea5SjE2Y6yvCeW5dYTn7PYMuW5ikXkvbGdcmSnXeaLjS",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18439/large/pai.png?1632004568",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "parrot-usd"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Particle Technology",
+      "symbol": "PART",
+      "address": "AVKnbqNQgXDY8kbnno9eSGfwpVz5idimBnDKiz1vbWAh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21302/large/logo.png?1638882252",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "particle-technology"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Partner Coin",
+      "symbol": "PTR",
+      "address": "3UcBMHnSTCXaxUbP6B96kHcED98DgEnNa9rGKzwXKMf4",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/21381/large/144531867-a8016f41-3b31-4d6f-97a1-372a58d48626.png?1639034184",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "partneroid"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "PayDex",
+      "symbol": "DPAY",
+      "address": "GyUYoBT1gcZBEVffWeGKQ3E2gzfNP5b8GEvnqAGjL6Hs",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26530/large/paydexlogo.png?1658666536",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "paydex"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Perseus Fintech",
+      "symbol": "PRS",
+      "address": "5idSc21Ht4FTC7jSNe34d6v5FmY8gonswYHpgC7QZCZW",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/26310/large/D39-q9sY_400x400.jpg?1657232052",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "perseus-fintech"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Phant",
+      "symbol": "PNT",
+      "address": "AKxR1NLTtPnsVcWwPSEGat1TC9da3Z2vX7sY4G7ZLj1r",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22799/large/logogradientsm.png?1642583142",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "phant"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Phantasia",
+      "symbol": "FANT",
+      "address": "FANTafPFBAt93BNJVpdu25pGPmca3RfwdsDsRrT3LX1r",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21604/large/Phantasia_Logo.png?1639553227",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "phantasia"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Physis",
+      "symbol": "PHY",
+      "address": "EswgBj2hZKdgovX2ihWSUDnuBg9VNbGmSGoH5yjNsPRa",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23087/large/PHY-icon-200x200.png?1643181312",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "physis"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Pigeon Sol",
+      "symbol": "PGNT",
+      "address": "BxHJqGtC629c55swCqWXFGA2rRF1igbbTmh22H8ePUWG",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/19579/large/logo-1024x1024.png?1635470197",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "pigeon-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Pixels.so",
+      "symbol": "PIXL",
+      "address": "5L2YboFbHAUpBDDJjvDB5M6pu9CW2FRjyDB2asZyvjtE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/21390/large/logo.png?1639036659",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "pixels-so"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Pizza Pug Coin",
+      "symbol": "PPUG",
+      "address": "E7WqtfRHcY8YW8z65u9WmD7CfMmvtrm2qPVicSzDxLaT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19574/large/zpWavjSG_400x400.jpg?1635459196",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "pizza-pug-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Player 2",
+      "symbol": "DEO",
+      "address": "DeoP2swMNa9d4SGcQkR82j4RYYeNhDjcTCwyzEhKwfAf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28811/large/logo_deo_small_200x200.png?1674453399",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "player-2"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Playground",
+      "symbol": "PLAYA",
+      "address": "E6oCGvmSYW7qhy7oeDfiNZLX6hEmPCVxBC8AknwAj82B",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24387/large/playa.PNG?1647502195",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "playground"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Playground Waves Floor Index",
+      "symbol": "WAVES",
+      "address": "4uRn7vxRPWYP4HuAa4UNXwEPLRL8oQ71YByMhr6yBnL4",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24388/large/playgorund_waves.PNG?1647502973",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "playground-waves-floor-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Plutonian DAO",
+      "symbol": "PLD",
+      "address": "2cJgFtnqjaoiu9fKVX3fny4Z4pRzuaqfJ3PBTMk2D9ur",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25092/large/logo-pld_200.png?1650270204",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "plutonian-dao"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "PlutusFi",
+      "symbol": "PLUT",
+      "address": "CiAkzbxkQCyY7hFtNeUHMbqiL8CXtbWaRnUJpJz5sBrE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27964/large/LeQ9aIhU_400x400.jpeg?1666754146",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "plutusfi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Poglana",
+      "symbol": "POG",
+      "address": "DfCqzB3mV3LuF2FWZ1GyXer4U5X118g8oUBExeUqzPss",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28742/large/pog-logo.png?1673840874",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "poglana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Pollen Coin",
+      "symbol": "PCN",
+      "address": "GWsZd8k85q2ie9SNycVSLeKkX7HLZfSsgx6Jdat9cjY1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25687/large/97762641.png?1653374572",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "pollen-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Portals Ivory Index",
+      "symbol": "IVRY",
+      "address": "2MtPZqwNKTNsBoFCwm4ZTWk3ySz4LSd82ucDGeTk7VNu",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24389/large/portal.PNG?1647503207",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "portals-ivory-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Port Finance",
+      "symbol": "PORT",
+      "address": "PoRTjZMPXb9T7dyU7tpLEZRQj7e6ssfAE62j2oQuc6y",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17607/large/d-k0Ezts_400x400.jpg?1628648715",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "port-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Positron",
+      "symbol": "POT",
+      "address": "9iz45n44TQUPyoRymdZXEunqvZUksZyhzS6zQ7sLMadj",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23910/large/logo.png?1645682226",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "positron-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Potato",
+      "symbol": "POTATO",
+      "address": "GEYrotdkRitGUK5UMv3aMttEhVAZLhRJMcG82zKYsaWB",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/18254/large/logocircle.png?1631151305",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "potato"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Prism",
+      "symbol": "PRISM",
+      "address": "PRSMNsEPqhGVCH1TtWiJqPjJyh2cKrLostPZTNy1o5x",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21475/large/7KzeGb1.png?1639350211",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "prism"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "ProtoReality Games",
+      "symbol": "PRGC",
+      "address": "66edZnAPEJSxnAK4SckuupssXpbu5doV57FUcghaqPsY",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25525/large/Bjh4zRK1_400x400.png?1652235059",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "protoreality-games"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "PSY Coin",
+      "symbol": "PSY",
+      "address": "49jpm8SpyTwaGaJfUa4AmU28hmW1HoKuqzXkgykysowU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22416/large/rHFKrmsJ_400x400.jpg?1641805324",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "psy-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "PsyOptions",
+      "symbol": "PSY",
+      "address": "PsyFiqqjiv41G7o5SMRzDJCu4psptThNR2GtfeGHfSq",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22784/large/download.png?1642580392",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "psyoptions"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "PUFF",
+      "symbol": "PUFF",
+      "address": "G9tt98aYSznRk7jWsfuz9FnTdokxS6Brohdo9hSmjTRB",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22049/large/logo_%281%29.png?1640675965",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "puff"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Quiztok",
+      "symbol": "QTCON",
+      "address": "DkNihsQs1hqEwf9TgKP8FmGv7dmMQ7hnKjS2ZSmMZZBE",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/8208/large/QTCON.png?1587543372",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "quiztok"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "RaceFi",
+      "symbol": "RACEFI",
+      "address": "AAmGoPDFLG6bE82BgZWjVi8k95tj9Tf3vUN7WvtUm2BU",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21873/large/XIF9z8Z6_400x400.jpg?1640209612",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "racefi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "RAD",
+      "symbol": "RAD",
+      "address": "B6aJ3TGfme3SMnLSouHXqWXjVFqYyqj7czzhzr8WJFAi",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/22854/large/unknown.png?1642750640",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rad"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Rally (Solana)",
+      "symbol": "SRLY",
+      "address": "sRLY3migNrkC1HLgqotpvi66qGkdNedqPZ9TJpAQhyh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23239/large/srly.png?1643531979",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rally-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ratio Protocol",
+      "symbol": "RATIO",
+      "address": "ratioMVg27rSZbSvBopUvsdrGUzeALUfFma61mpxc8J",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24543/large/ratio.png?1648108625",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ratio-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ratio Stable Coin",
+      "symbol": "USDR",
+      "address": "USDrbBQwQbQ2oWHUPfA8QBHcyVxKUq1xHyXsSLKdUq2",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26066/large/usdr_logo.png?1655469254",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ratio-stable-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Raydium",
+      "symbol": "RAY",
+      "address": "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6R",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/13928/large/PSigc4ie_400x400.jpg?1612875614",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "raydium"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Realy Metaverse",
+      "symbol": "REAL",
+      "address": "AD27ov5fVU2XzwsbvnFvb1JpCBaCB5dRXrczV9CqSVGb",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21448/large/2SIFWp0b_400x400.jpg?1639174188",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "realy-metaverse"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "renDOGE",
+      "symbol": "RENDOGE",
+      "address": "ArUkYE2XDKzqy77PRRGjo4wREWwqk6RXTfM9NeqzPvjU",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/13796/large/Dogecoin.jpg?1628072827",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rendoge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "renZEC",
+      "symbol": "RENZEC",
+      "address": "E99CQ2gFMmbiyK2bwiaFNWUUmwz4r8k2CVEFxwuvQ7ue",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/11564/large/Zcash.jpg?1628072865",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "renzec"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Republic Credits",
+      "symbol": "RPC",
+      "address": "EAefyXw6E8sny1cX3LTH6RSvtzH6E5EFy1XsE2AiH1f3",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25094/large/logo-rpc_200.png?1650270552",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "republic-credits"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Rice",
+      "symbol": "RICE",
+      "address": "5yw793FZPCaPcuUN4F61VJh2ehsFX87zvHbCA4oRebfn",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24010/large/rice_200_200.png?1646030160",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rice"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOL Tigers Roar",
+      "symbol": "ROAR",
+      "address": "DqxzPWQ2FKHn8pRoy9jCpA6M3GkEqYfieiAVwMYWVyXr",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20693/large/logo_-_2021-11-22T144644.880.png?1637563616",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "roar-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Rollbit Coin",
+      "symbol": "RLB",
+      "address": "RLBxxFkseAZ4RgJH3Sqn8jXxhmGoz9jWxDNJMh8pL7a",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24552/large/unziL6wO_400x400.jpg?1648134494",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rollbit-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Rope Token",
+      "symbol": "ROPE",
+      "address": "8PMHT4swUMtBzgHnh5U564N5sjPSiUz2cjEQzFnnP1Fo",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14661/large/rope-v6.png?1619606776",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "rope-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Run",
+      "symbol": "RUN",
+      "address": "6F9XriABHfWhit6zmMUYAQBSy6XK5VF1cHXuW5LDpRtC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21374/large/cZoMwlyl_400x400.jpg?1639032079",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "run"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Saber",
+      "symbol": "SBR",
+      "address": "Saber2gLauYim4Mvftnrasomsv6NvAuncvMEZwcLpD1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/17162/large/oYs_YFz8_400x400.jpg?1626678457",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "saber"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SAIL",
+      "symbol": "SAIL",
+      "address": "6kwTqmdQkJd8qRr9RjSnUX9XJ24RmJRSrU1rsragP97Y",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/16657/large/SAIL.png?1624608515",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sail"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Samo INU",
+      "symbol": "SINU",
+      "address": "Ac7GiHwC7vZU2y97GRh9rqCqqnKAAgopYrTAtKccHxUk",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21435/large/pWzeVcL.png?1639121293",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "samo-inu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Samoyedcoin",
+      "symbol": "SAMO",
+      "address": "7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15051/large/IXeEj5e.png?1619560738",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "samoyedcoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Samusky",
+      "symbol": "SAMU",
+      "address": "SAMUmmSvrE8yqtcG94oyP1Zu2P9t8PSRSV3vewsGtPM",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20187/large/tokenlogo200x200.png?1636635312",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "samusky-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Santaclaus",
+      "symbol": "SANTA",
+      "address": "EctmRn2jMAdTDvQdG7mxadyiTvhGZiGYNrt9PWe6zioG",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22211/large/logo_%281%29.png?1641195172",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "santaclaus"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sator",
+      "symbol": "SAO",
+      "address": "2HeykdKjzHKGm2LKHw8pDYwjKPiFEoXAz74dirhUgQvq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19410/large/sator-logo-CMC.png?1635211626",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sator"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SBF Coin",
+      "symbol": "SBFC",
+      "address": "AWW5UQfMBnPsTaaxCK7cSEmkj1kbX2zUrqvgKXStjBKx",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/16147/large/sbfcoin.png?1623123217",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sbf-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Scrap",
+      "symbol": "SCRAP",
+      "address": "6naWDMGNWwqffJnnXFLBCLaYu1y5U9Rohe5wwJPHvf1p",
+      "decimals": 3,
+      "logoURI": "https://assets.coingecko.com/coins/images/23086/large/bd1b1275fdc0ac1.png?1643181131",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "scrap"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Secret Skellies Society",
+      "symbol": "$CRYPT",
+      "address": "CRYPTi2V87Tu6aLc9gSwXM1wSLc6rjZh3TGC4GDRCecq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28865/large/plain-skull_Large_200x200.png?1674995037",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "secret-skellies-society"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Secretum",
+      "symbol": "SER",
+      "address": "HNpdP2rL6FR6jM3bDxFX2Zo32D1YG2ZCztf9zzCrKMEX",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25378/large/ser.png?1651410512",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "secretum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Seeded Network",
+      "symbol": "SEEDED",
+      "address": "seedEDBqu63tJ7PFqvcbwvThrYUkQeqT6NLf81kLibs",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23618/large/seeded.png?1644761600",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "seeded-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sentre",
+      "symbol": "SNTR",
+      "address": "SENBBKVCM7homnf5RX9zqpf1GFe935hnbU4uVzY1Y6M",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19268/large/sentre.PNG?1634866010",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sentre"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Serum",
+      "symbol": "SRM",
+      "address": "SRMuApVNdxXokk5GT7XD5cUUgXMBCoAz2LHeuAoKWRt",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/11970/large/serum-logo.png?1597121577",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "serum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Serum (Wormhole from Ethereum)",
+      "symbol": "SRMET",
+      "address": "xnorPhAzWXUczCP3KjU5yDxmKKZi5cSbxytQ1LgE3kG",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22978/large/SRMet_wh_small.png?1644224116",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "serum-wormhole-from-ethereum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shiba Inu (Wormhole)",
+      "symbol": "SHIB",
+      "address": "CiKu4eHsVrc1eueVQeHn7qhXTcVu95gSQmBpX4utjL9z",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22983/large/SHIB_wh_small.png?1644224437",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shiba-inu-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shibalana",
+      "symbol": "SHIBA",
+      "address": "Dhg9XnzJWzSQqH2aAnhPTEJHGQAkALDfD98MA499A7pa",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20003/large/output-onlinepngtools_%2810%29.png?1636364960",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shibalana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shiba Light",
+      "symbol": "SHIBT",
+      "address": "2946ofy854iifvXCQmHX2AJgxRBoQcchy1gfD26RtkHp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20744/large/logo_-_2021-11-23T101625.925.png?1637633795",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shiba-light"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shibana",
+      "symbol": "BANA",
+      "address": "BhPXDQio8xtNC6k5Bg5fnUVL9kGN8uvRDNwW8MZBu8DL",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/21234/large/solshib.png?1638758546",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shibana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shibaverse SHIVER",
+      "symbol": "SHIVER",
+      "address": "FGMTuwmVVz9hUJzA8shYiEnM16wsYDoSmYoy13UZe1kk",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19357/large/Shibaverse_Logo.png?1635128924",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shibaverse-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SHIBONK",
+      "symbol": "SBONK",
+      "address": "H1G6sZ1WDoMmMCFqBKAbg9gkQPCo1sKQtaJWz9dHmqZr",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28675/large/bonklogo2.png?1673161859",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shibonk-311f81df-a4ea-4f31-9e61-df0af8211bd7"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SHILL Token",
+      "symbol": "SHILL",
+      "address": "6cVgJUqo4nmvQpbgrDZwyfd6RwWw5bfnCamS3M9N1fd",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18176/large/SHILL_Logo.png?1630896205",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shill-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shoebill Coin",
+      "symbol": "SHBL",
+      "address": "7fCzz6ZDHm4UWC9Se1RPLmiyeuQ6kStxpcAP696EuE1E",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16160/large/sbl.png?1635612720",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "shoebill-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Single Earth",
+      "symbol": "MERIT",
+      "address": "HjUMVG3yQK7uMTq1TerG6C8JzAjRvMdYCoX7ZUzKTgjH",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27020/large/logo_%284%29.png?1661482963",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "single-earth"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Socean Staked Sol",
+      "symbol": "SCNSOL",
+      "address": "5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18468/large/biOTzfxE_400x400.png?1633662119",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "socean-staked-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solabrador",
+      "symbol": "SOLAB",
+      "address": "GLmaRDRmYd4u3YLfnj9eq1mrwxa1YfSweZYYZXZLTRdK",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21014/large/2ZR6Gkz.png?1638190959",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solabrador"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolaLambo",
+      "symbol": "SOB",
+      "address": "EkDf4Nt89x4Usnxkj4sGHX7sWxkmmpiBzA4qdDkgEN6b",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19908/large/SOLA-LAMBO-2.png?1636104328",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solalambo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solana Ecosystem Index",
+      "symbol": "SOLI",
+      "address": "8JnNWJ46yfdq8sKgT1Lk4G7VWkAA8Rhh7LhqgJ6WY41G",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23550/large/Token-SOLI-200x200.png?1644460319",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solana-ecosystem-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solana Inu",
+      "symbol": "INU",
+      "address": "5jFnsfx36DyGk8uVGrbXnVUMTsBkPXGpx6e69BiGFzko",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20020/large/YGid9wMv_400x400.jpg?1636412528",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solana-inu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solana Nut",
+      "symbol": "SOLNUT",
+      "address": "Fv3ZG56M2cWvF8sy9VWzWyvtHPhugNc1BAzpyoAPvL7r",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/21961/large/20211210_004320.png?1640521375",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solana-nut"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solana Paws",
+      "symbol": "PAWS",
+      "address": "6bLp99VoqKU1C3Qp6VTNvSoCoc78jMGxPkGSSopq8wHB",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/20779/large/logo-1.png?1637667957",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solana-paws"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolanaPrime",
+      "symbol": "PRIME",
+      "address": "PRiME7gDoiG1vGr95a3CRMv9xHY7UGjd4JKvfSkmQu2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25911/large/solana_black200x200.png?1654587637",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solanaprime"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolanaSail Governance",
+      "symbol": "GSAIL",
+      "address": "Gsai2KN28MTGcSZ1gKYFswUpFpS7EM9mvdR9c8f6iVXJ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17658/large/logo_GSAIL.png?1628758657",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solanasail-governance-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solanax",
+      "symbol": "SOLD",
+      "address": "5v6tZ1SiAi7G8Qg4rBF1ZdAn4cn6aeQtefewMr1NLy61",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17634/large/sold.png?1639988619",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solanax"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sola Ninja",
+      "symbol": "SNJ",
+      "address": "Hj4sTP4L4rvR9WBR6KyK99sxPptBQQczNWe4y15mxhRD",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19730/large/logo_-_2021-11-01T200443.131.png?1635768291",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sola-ninja"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solanium",
+      "symbol": "SLIM",
+      "address": "xxxxa1sKNGwFtw2kFn8XauW9xq8hBZ5kVtcSesTT9fW",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15816/large/logo_cg.png?1659000206",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solanium"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solanyx",
+      "symbol": "SYX",
+      "address": "94jMUy411XNUw1CnkFr2514fq6KRc49W3kAmrjJiuZLx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21964/large/logo.png?1640524913",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solanyx"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOLAPE",
+      "symbol": "SOLAPE",
+      "address": "GHvFFSZ9BctWsEc5nujR1MTmmJWY7tgQz2AXE6WVFtGN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16930/large/128px-coin.png?1625753550",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solape-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solar",
+      "symbol": "SOLAR",
+      "address": "2wmKXX1xsxLfrvjEPrt2UHiqj8Gbzwxvffr9qmNjsw8g",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21605/large/pl_YJ2Ug_400x400.jpg?1639553279",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solar"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solar Bear",
+      "symbol": "SOLBEAR",
+      "address": "DktNJUJAWJyeLw3ykCkFNpGohE24SoEhevKBskRi6P1y",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20778/large/logo.png?1637665136",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solar-bear"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solareum Wallet",
+      "symbol": "XSB",
+      "address": "4UuGQgkD3rSeoXatXRWwRfRd21G87d5LiCfkVzNNv1Tt",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20958/large/xsb-200.png?1638141904",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solareum-wallet"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOLA",
+      "symbol": "SOLA",
+      "address": "FYfQ9uaRaYvRiaEGUmct45F9WKam3BYXArTrotnTNFXF",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18263/large/sola-new.png?1632238376",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sola-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOLA-X",
+      "symbol": "SAX",
+      "address": "SAX2cChnuhnKfUDERWVHyd8CoeDNR4NjoxwjuW8uiqa",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28319/large/20211216_SOLA-X_Logo_Colored_RGB-06.png?1669364885",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sola-x"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOL Baby Doge",
+      "symbol": "SBABYDOGE",
+      "address": "BABYsocP6cB95xvBDXnjXKX96VBNC37dmNWUtaV9Jk6v",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/21436/large/logo_%282%29.png?1639121887",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sol-baby-doge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solbank",
+      "symbol": "SBNK",
+      "address": "uNrix3Q5g51MCEUrYBUEBDdQ96RQDQspQJJnnQ4T3Vc",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18513/large/yo_gS6Hi_400x400.png?1632218794",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solbank-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solberg",
+      "symbol": "SLB",
+      "address": "2uRFEWRBQLEKpLmF8mohFZGDcFQmrkQEEZmHQvMUBvY7",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18918/large/logo_%2822%29.png?1633922185",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solberg"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolBerry",
+      "symbol": "SOLBERRY",
+      "address": "EWS2ATMt5fQk89NWLJYNRmGaNoji8MhFZkUB4DiWCCcz",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18562/large/logo200_%2826%29.png?1632441730",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solberry"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solcats",
+      "symbol": "MEOW",
+      "address": "HAgX1HSfok8DohiNCS54FnC2UJkDSrRVnT38W3iWFwc8",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20035/large/solcats_logo.jpg?1636423998",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solcats"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolChicks Shards",
+      "symbol": "SHARDS",
+      "address": "8j3hXRK5rdoZ2vSpGLRmXtWmW6iYaRUw5xVk4Kzmc9Hp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23728/large/logo_%282%29.png?1645163819",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solchicks-shards"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolChicks",
+      "symbol": "CHICKS",
+      "address": "cxxShYRVcepDudXhe7U62QHvw8uBJoKFifmzggGKVC2",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20978/large/chicks.png?1638162821",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solchicks-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solcial",
+      "symbol": "SLCL",
+      "address": "SLCLww7nc1PD2gQPQdGayHviVVcpMthnqUz2iWKhNQV",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24583/large/1_N9szP0_400x400.jpg?1648217020",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solcial"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolClout",
+      "symbol": "SCT",
+      "address": "4Te4KJgjtnZe4aE2zne8G4NPfrPjCwDmaiEx9rKnyDVZ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21638/large/solclout.jpg?1639630028",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solclout"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolCondoms",
+      "symbol": "CONDOMS",
+      "address": "EzL6LLmv4vgfF7irkjG7ZxM92bTJ9f6nFopDXJTow7zj",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21814/large/DboqD2_o_400x400.jpg?1640071580",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solcondoms"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solcubator",
+      "symbol": "SOLC",
+      "address": "Bx1fDtvTN6NvE4kjdPHQXtmGSg582bZx9fGy4DQNMmAT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18682/large/Solcubator-Logo-Icon.png?1632966591",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solcubator"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolDate",
+      "symbol": "DATE",
+      "address": "Ce3PSQfkxT5ua4r2JqCoWYrMwKWC5hEzwsrT9Hb7mAz9",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18461/large/date.PNG?1632108952",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soldate-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solderland",
+      "symbol": "SLDR",
+      "address": "9ZLBKPCzkvDv85hojKofsogsESkJMN164QCVUtxvBxEQ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25284/large/logo.jpg?1651128638",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solderland"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Soldex",
+      "symbol": "SOLX",
+      "address": "CH74tuRLTYcxG7qNJCsV9rghfLXJCQJbsu7i52a8F1Gn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21362/large/output-onlinepngtools_%2811%29.png?1639014832",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soldex"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolDoge",
+      "symbol": "SDOGE",
+      "address": "8ymi88q5DtmdNTn2sPRNFkvMkszMHuLJ1e3RVdWjPa3s",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/19746/large/2L4aX1r.png?1635822424",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soldoge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solend",
+      "symbol": "SLND",
+      "address": "SLNDpmoWTVADgEdndyvWzroNL7zSi1dF9PC3xHGtPwp",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19573/large/i6AMOwun_400x400.jpg?1635458597",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solend"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solex Finance",
+      "symbol": "SLX",
+      "address": "AASdD9rAefJ4PP7iM89MYUsQEyCQwvBofhceZUGDh5HZ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19392/large/logo_-_2021-10-25T161153.717.png?1635149522",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solex-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tulip Protocol",
+      "symbol": "TULIP",
+      "address": "TuLipcqtGVXP9XR62wM8WWCm6a9vhLs7T1uoWBk6FDs",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15764/large/TqrUdBG.png?1621827144",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solfarm"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solfina",
+      "symbol": "SOLFI",
+      "address": "3CaBxqxWsP5oqS84Pkja4wLxyZYsHzMivQbnfwFJQeL1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20729/large/dDDqpMiA_400x400.jpg?1637616143",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solfina"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solfire Finance",
+      "symbol": "FIRE",
+      "address": "AfXLBfMZd32pN6QauazHCd7diEWoBgw1GNUALDw3suVZ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22305/large/logo.png?1641446227",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solfire-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SOL Flowers",
+      "symbol": "FLWR",
+      "address": "HDVR9Edy2o8uRdf5xFUDSGVLo556UjAaNR9BrwZ8QeMJ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23534/large/FLWR-Token-Front-ALPHA.png?1644387944",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sol-flowers"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solge",
+      "symbol": "SOLGE",
+      "address": "FM8ai6JTyf6HWAgPbnsdonqCeWfjomPMFfnBgPSf23W2",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/28678/large/solge_%281%29.png?1673231982",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solice",
+      "symbol": "SLC",
+      "address": "METAmTMXwdb8gYzyCPfXXFmZZw4rUsXX58PNsDg7zjL",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22115/large/solice_logo_200x200.png?1640845206",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solice"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solid Protocol",
+      "symbol": "SOLID",
+      "address": "A5UevXJdphkzXhRtTXj8JyoYYrWnkCLHVS986JHtRLyj",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22100/large/logo.png?1640797686",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solid-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solily Protocol",
+      "symbol": "LILY",
+      "address": "LiLyT885cG9xZKYQk9x6VWMzmcui4ueV9J1uzPDDajY",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25611/large/logo200.png?1652846780",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solily-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solit",
+      "symbol": "SLT",
+      "address": "SLT3iSYKeBuCyxvnfij4RUhMfKxZCY3s12Z5pfkTXhV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20553/large/logo_-_2021-11-18T112941.579.png?1637206190",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solit"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sollama Utilities",
+      "symbol": "SOLLAMA",
+      "address": "ENvD2Y49D6LQwKTtcxnKBmEMmSYJPWMxXhNsAo18jxNc",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28902/large/newTPLogoSollama.png?1675237565",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sollama-utilities"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solminter",
+      "symbol": "SMRT",
+      "address": "95KN8q3qubEVjPf9trgyur2nHx8T5RCmztRbLuQ5E5i",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/17937/large/apple-touch-icon.png?1629868107",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solminter"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solootbox DAO",
+      "symbol": "BOX",
+      "address": "DysbQiM8nPdZbBhvHM1EgcSE73EwtFWDanXwY8CDD3Jn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22660/large/qggoHE1__400x400.jpg?1642401842",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solootbox-dao"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solpad Finance",
+      "symbol": "SOLPAD",
+      "address": "GfJ3Vq2eSTYf1hJP6kKLE9RT6u7jF9gNszJhZwo5VPZp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16368/large/solpad.PNG?1623820231",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solpad-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolPatrol Bail",
+      "symbol": "BAIL",
+      "address": "3e9pHUxa2nvAqso2Kr2KqJxYvZaz9qZLjoLaG77uQwB1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25787/large/hammer.png?1653882632",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solpatrol-bail"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolPay Finance",
+      "symbol": "SOLPAY",
+      "address": "zwqe1Nd4eiWyCcqdo4FgCq7LYZHdSeGKKudv6RwiAEn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22766/large/1_wTkhKXbxhBQxR1BW5WKSNA.png?1642575140",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solpay-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolRazr",
+      "symbol": "SOLR",
+      "address": "7j7H7sgsnNDeCngAPjpaCN4aaaru4HS7NAFYSEUyzJ3k",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18390/large/Sol-Razr-Logo-TICKER.png?1631759669",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solrazr"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solrise Finance",
+      "symbol": "SLRS",
+      "address": "SLRSSpSLUTP7okbCUBYStWCo1vUgyt775faPqz8HUMr",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/15762/large/9989.png?1621825696",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solrise-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solster",
+      "symbol": "STR",
+      "address": "9zoqdwEBKWEi9G5Ze8BSkdmppxGgVv1Kw4LuigDiNr9m",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18621/large/log-350.png?1632701442",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solster"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Soltato FRIES",
+      "symbol": "FRIES",
+      "address": "FriCEbw1V99GwrJRXPnSQ6su2TabHabNxiZ3VNsVFPPN",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19533/large/soltato.png?1635745612",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soltato-fries"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solum",
+      "symbol": "SOLUM",
+      "address": "9XtRZwKzDXEJ61A7qCqbPz8jXMYHGT3LwxqrEzB6fqxv",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18945/large/logo_-_2021-10-12T103445.624.png?1634006093",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Soluna",
+      "symbol": "SLNA",
+      "address": "SLNAAQ8VT6DRDc3W9UPDjFyRt7u4mzh8Z4WYMDjJc35",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24845/large/icon.f97a40025f9cd28101e4903f23b304ff.png?1649112521",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soluna"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "solUST",
+      "symbol": "SOLUST",
+      "address": "JAa3gQySiTi8tH3dpkvgztJWHQC1vGXr5m6SQ9LEM55T",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/25372/large/solust.png?1651406405",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solust"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solvent",
+      "symbol": "SVT",
+      "address": "svtMpL5eQzdmB3uqK9NXaQkq8prGZoKQFNVJghdWCkV",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22387/large/svt.png?1641789503",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solvent"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solview",
+      "symbol": "SOLV",
+      "address": "7q3AdgKuMeDRnjaMQs7ppXjaw4HUxjsdyMrrfiSZraiN",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20482/large/solview_logo_515x515.png?1645502773",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solview"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SolX Gaming Guild",
+      "symbol": "SGG",
+      "address": "3eLpKZBgu6pKG2TSpvTfTeeimT294yxV2AEiBKZdY2ai",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22673/large/YhhMhwOn_400x400.jpg?1642405643",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solx-gaming-guild"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Solyard Finance",
+      "symbol": "YARD",
+      "address": "8RYSc3rrS4X4bvBCtSJnhcpPpMaAJkXnVKZPzANxQHgz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18400/large/IMG_7306.JPG?1631775657",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "solyard-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SonarWatch",
+      "symbol": "SONAR",
+      "address": "sonarX4VtVkQemriJeLm6CKeW3GDMyiBnnAEMw1MRAE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20494/large/S_7gaWIC_400x400.png?1637131427",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sonarwatch"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Soul Dogs City Bones",
+      "symbol": "BONES",
+      "address": "bonegFPgrpZ4bfVn3kQK1aMbGYddWtfMAywNt5LsuVE",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/25025/large/JEepabYB_400x400.png?1649838257",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soul-dog-city-bones"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SouloCoin",
+      "symbol": "SOULO",
+      "address": "Gz3u6eJaKEviYpPC5AwUziz891kNX76PNdsmJrnaNNY4",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22082/large/logo.png?1640759758",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "soulocoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Space Hamster",
+      "symbol": "HAMS",
+      "address": "A2T2jDe2bxyEHkKtS8AtrTRmJ9VZRwyY8Kr7oQ8xNyfb",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18455/large/logo_-_2021-09-20T105215.999.png?1632106402",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "space-hamster"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sphinxel",
+      "symbol": "SPX",
+      "address": "H6JocWxg5g1Lcs4oPnBecmjQ4Y1bkZhGJHtjMunmjyrp",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20249/large/logo_-_2021-11-12T151134.139.png?1636701101",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sphinxel"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Spookeletons",
+      "symbol": "SPKL",
+      "address": "31tCNEE6LiL9yW4Bu153Dq4vi2GuorXxCA9pW9aA6ecU",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20086/large/14169.png?1636458787",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "spookeletons-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Star Atlas",
+      "symbol": "ATLAS",
+      "address": "ATLASXmbPQxBUYbxPsV97usA3fPQYEqzQBUHgiFCUsXx",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17659/large/Icon_Reverse.png?1628759092",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "star-atlas"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Star Atlas DAO",
+      "symbol": "POLIS",
+      "address": "poLisWXnNRwC6oBu1vHiuKQzFjGL4XDSu4g9qjz9qVk",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17789/large/POLIS.jpg?1629256006",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "star-atlas-dao"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Starbots",
+      "symbol": "BOT",
+      "address": "AkhdZGVbJXPuQZ53u2LrimCjkRP6ZyxG1SoM85T98eE1",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/21823/large/coin_%286%29.png?1640076014",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "starbots"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Starbots GEAR",
+      "symbol": "GEAR",
+      "address": "23WuycvPjEuzJTsBPBZqnbFZFcBtBKAMTowUDHwagkuD",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/26651/large/logo_%282%29.png?1659408350",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "starbots-gear"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Star Chain",
+      "symbol": "STAR",
+      "address": "EXGqHqvKBs4Z1mCwhiGE7kT2TXGFirAjvQzPSQP8nvuw",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25848/large/logo.png?1654150342",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "star-chain"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "StarLaunch",
+      "symbol": "STARS",
+      "address": "HCgybxq5Upy8Mccihrp7EsmwwFqYZtrHrsmsKwtGXLgW",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20109/large/OP3eksDQ_400x400.png?1636513478",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "starlaunch"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Step Finance",
+      "symbol": "STEP",
+      "address": "StepAscQoEioFxxWGnh2sLBDFp9d8rvKz2Yp39iDpyT",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/14988/large/step.png?1619274762",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "step-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "STEPN",
+      "symbol": "GMT",
+      "address": "7i5KKsX2weiTkry7jA4ZwSuXGhs5eJBEjY8vVxR4pfRx",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23597/large/gmt.png?1644658792",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "stepn"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Stoned Ape Crew Index",
+      "symbol": "SAC",
+      "address": "GZL4yjPohDShW4RofJ6dEWu2Fv7qEa5mBT7Dpje5hqe7",
+      "decimals": 2,
+      "logoURI": "https://assets.coingecko.com/coins/images/24385/large/stone_ape.PNG?1647501586",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "stoned-ape-crew-index"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Style",
+      "symbol": "STYLE",
+      "address": "3FHpkMTQ3QyAJoLoXVdBpH4TfHiehnL2kXmv9UXBpYuF",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28060/large/78oZvtZW_400x400.jpeg?1667442304",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "style"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Such Shiba",
+      "symbol": "SUCH",
+      "address": "HnZiKrSKYQkEfzjQs6qkvuGbBmrBP9YzjB1SMM7tiGZ1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25100/large/1CA10540-30AB-4F34-AF3A-9E8F88471FDF.png?1650284205",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "such-shiba"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sunny Aggregator",
+      "symbol": "SUNNY",
+      "address": "SUNNYWgPQmFxe9wTZzNK7iPnJ3vYDrkgnxJRJm1s3ag",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18039/large/90dbe787-8e5f-473c-b923-fe138a7a30ea.png?1630314924",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sunny-aggregator"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SunnySideUp",
+      "symbol": "SSU",
+      "address": "AGkFkKgXUEP7ZXazza5a25bSKbz5dDpgafPhqywuQnpf",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23369/large/logo.png?1643954242",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sunnysideup"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SuperBonds",
+      "symbol": "SB",
+      "address": "SuperbZyz7TsSdSoFAZ6RYHfAWe9NmjXBLVQpS8hqdx",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22743/large/ywws9ojM_400x400.jpg?1642548336",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "superbonds"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sushi",
+      "symbol": "SUSHI",
+      "address": "ChVzxWRmrTeSgwd3Ui3UumcN8KX7VK3WaD4KGeSKpypj",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/12271/large/512x512_Logo_no_chop.png?1606986688",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sushi"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Swanlana",
+      "symbol": "SWAN",
+      "address": "SWANaZUGxF82KyVsbxeeNsMaVECtimze5VyCdywkvkH",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18425/large/SWANLANA_PNG.png?1631866031",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "swanlana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "SWERVE Protocol",
+      "symbol": "SWERVE",
+      "address": "45ojchnvC3agGNvs86MWBq8N4miiTY6X8ECQzgQNDE4v",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20858/large/94614403.png?1637801748",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "swerve-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Swole Doge",
+      "symbol": "SWOLE",
+      "address": "4BzxVoBQzwKoqm1dQc78r42Yby3EzAeZmMiYFdCjeu5Z",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19643/large/swole.png?1635853067",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "swole-doge"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synchrony",
+      "symbol": "SCY",
+      "address": "SCYfrGCw8aDiqdgcpdGjV6jp4UVVQLuphxTDLNWu36f",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19308/large/SYNCHRONY-LOGO.png?1634973091",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synchrony"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synesis One",
+      "symbol": "SNS",
+      "address": "SNSNkV9zfG5ZKWQs6x4hxvBRV6s8SqMfSGCtECDvdMd",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23289/large/sns.png?1643549030",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synesis-one"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synex Coin",
+      "symbol": "MINECRAFT",
+      "address": "FTkj421DxbS1wajE74J34BJ5a1o9ccA97PkK6mYq9hNQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21247/large/logo_-_2021-12-06T135451.604.png?1638770098",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synex-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synthetic FTT",
+      "symbol": "XFTT",
+      "address": "Fr3W7NPVvdVbwMcHgA7Gx2wUxP43txdsn3iULJGFbKz9",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/20025/large/BGYHyQ4.png?1636418021",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synthetic-ftt"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synthetic SOL",
+      "symbol": "XSOL",
+      "address": "BdUJucPJyjkHxLMv6ipKNUhSeY3DWrVtgxAES1iSBAov",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20022/large/mmJpy6j.png?1636417738",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synthetic-sol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synthetic USD",
+      "symbol": "XUSD",
+      "address": "83LGLCm7QKpYZbX8q4W2kYWbtt8NJBwbVwEepzkVnJ9y",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/19596/large/uJzDI4j.png?1635488810",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synthetic-usd"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Synthetify",
+      "symbol": "SNY",
+      "address": "4dmKkXNHdgYsXqBHCuMikNQWwVomZURhYvkkX5c4pQ7y",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/14835/large/synthetify_token.png?1618611507",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "synthetify-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Sypool",
+      "symbol": "SYP",
+      "address": "FnKE9n6aGjQoNWRBZXy4RW6LZVao7qwBonUbiD7edUmZ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18518/large/sypool.PNG?1632268218",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "sypool"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TabTrader",
+      "symbol": "TTT",
+      "address": "FNFKRV3V8DtA3gVJN6UshMiLGYA8izxFwkNWmJbFjmRj",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21060/large/xFYsZV9U_400x400.jpg?1638268495",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tabtrader"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Taki",
+      "symbol": "TAKI",
+      "address": "Taki7fi3Zicv7Du1xNAWLaf6mRK7ikdn77HeGzgwvo4",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25271/large/logo.png?1651118069",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "taki"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tap Fantasy MC",
+      "symbol": "TFMC",
+      "address": "FYUkUybywqUUyrUwiAezbvhTp2DUgx1eg8tQNiKkXqJ9",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26483/large/Tap-Fantasy-MC-Logo.png?1658279327",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tap-fantasy-mc"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TerraUSD (Wormhole)",
+      "symbol": "UST",
+      "address": "9vMJfxuKxXBoEa7rM12mYLMwTacLMLDJqHozw96WQL8i",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21150/large/UST_wh_small.png?1644223065",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "terrausd-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tether",
+      "symbol": "USDT",
+      "address": "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/325/large/Tether.png?1668148663",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tether"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tether USD (PoS) (Wormhole)",
+      "symbol": "USDTPO",
+      "address": "5goWRao6a3yNC4d6UjMdQxonkCMvKBwdpubU3qhfcdf1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22944/large/USDTpo_wh_small.png?1644223159",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tether-usd-pos-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tether USD (Wormhole from Ethereum)",
+      "symbol": "USDTET",
+      "address": "Dn4noZ5jgGfkntzcQSUZ8czkreiZ1ForXYoV2H8Dm7S1",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23025/large/USDTet_wh_small.png?1644223203",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tether-usd-wormhole-from-ethereum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "4thpillar technologies",
+      "symbol": "FOUR",
+      "address": "DAtU322C23YpoZyWBm8szk12QyqHa9rUQe1EYXzbm1JE",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/3434/large/four-ticker-2021-256x256.png?1617702287",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "the-4th-pillar"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Theca",
+      "symbol": "THECA",
+      "address": "D3cm6WRnyBct3p7vFqyTt2CaynsGPuVQT2zW6WHSTX6q",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21782/large/logo_%281%29.png?1640007283",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "theca"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "The Sandbox (Wormhole)",
+      "symbol": "SAND",
+      "address": "49c7WuCZkQgc3M4qH8WuEUNXfgwupZf1xqWkDQ7gjRGt",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22984/large/SAND_wh_small.png?1644224523",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "the-sandbox-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TheSolanDAO",
+      "symbol": "SDO",
+      "address": "7SZUnH7H9KptyJkUhJ5L4Kee5fFAbqVgCHvt7B6wg4Xc",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/22427/large/sdo-new_osvgbz.jpg?1641821718",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "thesolandao"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "The Starship Finance",
+      "symbol": "BIP",
+      "address": "FoqP7aTaibT5npFKYKQQdyonL99vkW8YALNPwWepdvf5",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21587/large/logo_-_2021-12-15T120333.709.png?1639541030",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "the-starship-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "The Xenobots Project",
+      "symbol": "XENO",
+      "address": "Bwfe7DwmEDvjEBZGbQnDU8CrwZsuvYaed1VuQ8KDTGsS",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/24054/large/W3OlCRoK_400x400.jpg?1646201237",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "the-xenobots-project"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ticket Finance",
+      "symbol": "TICKET",
+      "address": "AymKzSDznoLT7Vhsb4wSRnCj1gjcG3zkgYFY8fxsHHer",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22756/large/PK65p32H_400x400.jpg?1642573249",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ticket-finance"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tiny Bonez",
+      "symbol": "T1NY",
+      "address": "C5xtJBKm24WTt3JiXrvguv7vHCe7CknDB7PNabp4eYX6",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24426/large/coin.png?1647848074",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tiny-bonez"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tiny Colony",
+      "symbol": "TINY",
+      "address": "HKfs24UEDQpHS5hUyKYkHd9q7GY5UQ679q2bokeL2whu",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22264/large/Kq4gAMJi_400x400.png?1641336657",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tiny-colony"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TokenBook",
+      "symbol": "TBK",
+      "address": "2mDJPcvv7vigZo9ZPxhHLpKQSixCkbohVY35eX6NkN6m",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20334/large/RyESzumQ_400x400.jpg?1636937939",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tokenbook"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TOPSS",
+      "symbol": "TOPSS",
+      "address": "2pVkjwPJHXopCknbdsHgXQnhptEWWWkfiw6pDcnNnBPC",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/27508/large/Topss_logo_final_logo_light.png?1664334182",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "topss"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "TORG",
+      "symbol": "TORG",
+      "address": "AbnTggpTujbdAiJtyhH9WtK2CqXk44W7GipyJXkopBDd",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/17596/large/TORG_Logo_200x200.png?1628586056",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "torg"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Tribeland",
+      "symbol": "TRBL",
+      "address": "3CKQgrcvwhvFqVXXxLTb1u262nh26SJ3uutkSCTtbZxH",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21728/large/15994.png?1639964642",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tribeland"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "trollbox",
+      "symbol": "TOX",
+      "address": "Bx4ykEMurwPQBAFNvthGj73fMBVTvHa8e9cbAyaK4ZSh",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16903/large/trollbox-200.png?1625578606",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "trollbox"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "tudaBirds",
+      "symbol": "BURD",
+      "address": "Qikhhhg9Ta3Jg7WoDFbSYuCAE14hx9hPvdz1zVp3zUw",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22839/large/_TOvRxfx_400x400.jpg?1642745695",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "tudabirds"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Turnt Up Tikis",
+      "symbol": "TUT",
+      "address": "6wShYhqA2gs3HUAZ4MyaPDpKPBWFJUQQUGaCoy2k1Tgz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22007/large/exiled.2e9d4c91.png?1640589892",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "turnt-up-tikis"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Turtles",
+      "symbol": "TRTLS",
+      "address": "q4bpaRKw3fJB1AJBeeBaKv3TjYzWsmntLgnSB275YUb",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21017/large/turtles200x200.png?1638191778",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "turtles-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Twirl Governance",
+      "symbol": "TGT",
+      "address": "FciGvHj9FjgSGgCBF1b9HY814FM9D28NijDd5SJrKvPo",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/16725/large/Yn1ebvX.png?1624850650",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "twirl-governance-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "MILK",
+      "symbol": "MILK",
+      "address": "MLKmUCaj1dpBY881aFsrBwR9RUMoKic8SWT3u1q5Nkj",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/27168/large/UClogoMLKtoken.png?1662285921",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "udder-chaos-milk"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "UncleMine",
+      "symbol": "UM",
+      "address": "DMCUFm2ZAnSU7UgsdVq23gRogMU3MEBjPgQF1gK53rEn",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22871/large/unclemine_icon_400.png?1642756525",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "unclemine"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Uniswap (Wormhole)",
+      "symbol": "UNI",
+      "address": "8FU95xFJhUUkyyCLU13HSzDLs7oC4QZdXQHL6SCeab36",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/22969/large/UNI_wh_small.png?1644223592",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "uniswap-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Unique Venture clubs",
+      "symbol": "UNQ",
+      "address": "UNQtEecZ5Zb4gSSVHCAWUQEoNnSVEbWiKCi1v9kdUJJ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21730/large/unq.png?1659789179",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "unq"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "UPFI Network",
+      "symbol": "UPS",
+      "address": "EwJN2GqUGXXzYmoAciwuABtorHczTA5LqbukKXV1viH7",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20179/large/logo_-_2021-11-11T122041.439.png?1636604452",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "upfi-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "USD Coin",
+      "symbol": "USDC",
+      "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/6319/large/USD_Coin_icon.png?1547042389",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "usd-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "USD Coin (PoS) (Wormhole)",
+      "symbol": "USDCPO",
+      "address": "E2VmbootbVCBkMNNxKQgCLMS1X3NoGMaYAsufaAsf7M",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22945/large/USDCpo_wh_small.png?1644223406",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "usd-coin-pos-wormhole"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "USD Coin (Wormhole from Ethereum)",
+      "symbol": "USDCET",
+      "address": "A9mUU4qviSctJVPJdBJWkb28deg915LYJKrzQ19ji3FM",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23019/large/USDCet_wh_small.png?1644223449",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "usd-coin-wormhole-from-ethereum"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "USDH",
+      "symbol": "USDH",
+      "address": "USDH1SM1ojwWUga67PGrgFWUHibbjqMvuMaDkRJTgkX",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22941/large/USDH_icon.png?1643008131",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "usdh"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "UXD Protocol",
+      "symbol": "UXP",
+      "address": "UXPhBoR3qG4UCiGNJfV7MqhHyFqKN68g45GoYvAeL2M",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/20319/large/UXP.jpg?1636864568",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "uxd-protocol-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "UXD Stablecoin",
+      "symbol": "UXD",
+      "address": "7kbnvuGBxxj8AG9qp8Scn56muWGaRaFqxg1FsRp3PaFT",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/22850/large/UXD-White.png?1642747473",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "uxd-stablecoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Verasaw Plant",
+      "symbol": "VRS",
+      "address": "2YCQcQgy9nNhgukjAur1jCvMXgSTQ5FVDc3ae3BcspXS",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26110/large/17-56-48-vrs.png?1655884668",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "verasaw-plant-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Viral Inu",
+      "symbol": "VINU",
+      "address": "CgbJxXyaHeU8VsquBpySuFXA94b6LWXxioZ28wRr8fs9",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20698/large/vinu.png?1642917940",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "viral-inu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "VisionGame",
+      "symbol": "VISION",
+      "address": "HVkFqcMHevVPb4XKrf4XowjEaVVsBoqJ2U1EG59Dfk5j",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24460/large/eQh2HGH3_400x400.jpg?1647679828",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "visiongame"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Vitall Markets",
+      "symbol": "VITAL",
+      "address": "2FKuYE5D75e9Fjg3ymGBrFfVc8tVKac4SeyvZn5dGNUz",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21923/large/logo.png?1640267906",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "vitall-markets"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Vivaion",
+      "symbol": "VIVAION",
+      "address": "2jw1uFmc1hhfJH3EqGhaE2rfZMMC2YBpxkZcdUbPppMn",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22797/large/zCKgUOy13nTdqluJ1VWG2aqDfMgD4axJt_g4C9T-W3I.png?1650957408",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "vivaion"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Void Games",
+      "symbol": "VOID",
+      "address": "DjPt6xxMoZx1DyyWUHGs4mwqWWX48Fwf6ZJgqv2F9qwc",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21307/large/h5lkasZH_400x400.jpg?1638886042",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "void-games"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "VooVoo",
+      "symbol": "VOO",
+      "address": "55t1PfJngPgMS4c4HeSHPy54VWfkMEk7XBQhSkdz6Cm6",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22827/large/WhatsApp_Image_2021-11-02_at_16.53.29.jpeg?1642664051",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "voovoo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Vybit",
+      "symbol": "VI",
+      "address": "7zBWymxbZt7PVHQzfi3i85frc1YRiQc23K7bh3gos8ZC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/10978/large/vi.png?1639659576",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "vybit"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "VYNK Chain",
+      "symbol": "VYNC",
+      "address": "A5NF1e6RnYkVwtg3V3z1qeUz4PZfHCXmQ9RotuJWgi6F",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/17743/large/vynk_chain.PNG?1629150126",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "vynk-chain"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Waggle Network",
+      "symbol": "WAG",
+      "address": "5tN42n9vMi6ubp67Uy4NnmM5DMZYN8aS8GeB3bEDHr6E",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/18696/large/waggle.PNG?1633750177",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "waggle-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WAGMI On Solana",
+      "symbol": "WAGMI",
+      "address": "3m7A2A8HHdqmiDrjAfaddj7Hxd88FrBHA1KSoqjoELtu",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/21069/large/logo.png?1638279903",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wagmi-on-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Walken",
+      "symbol": "WLKN",
+      "address": "EcQCUYv57C4V6RoPxkVUiDwtX1SP8y8FP5AEToYL8Az",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/25566/large/wlkn.jpg?1652523301",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "walken"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Ween",
+      "symbol": "WEENS",
+      "address": "DmXfDUeyRJqnpvdjssGgUXwZrRFPXvu2DfMq4jfTTC9C",
+      "decimals": 0,
+      "logoURI": "https://assets.coingecko.com/coins/images/21764/large/logo_%281%29.png?1639991986",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "ween-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WeSleep",
+      "symbol": "WEZ",
+      "address": "9igG1YEgda7M2LjWkCiaKwcwYkFW174VDzrrPvoAT6DJ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/28265/large/Logo_WEZ_png.png?1668766709",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wesleep"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WEYU",
+      "symbol": "WEYU",
+      "address": "EHaEBhYHWA7HSphorXXosysJem6qF4agccoqDqQKCUge",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/18112/large/weyu.PNG?1630542552",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "weyu"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Whalemap",
+      "symbol": "WMP",
+      "address": "BygDd5LURoqztD3xETc99WCxLUbTi6WYSht9XiBgZ4HW",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21892/large/logo-token_%281%29.png?1640228860",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "whalemap"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Shredded Apes Whey",
+      "symbol": "WHEY",
+      "address": "5fTwKZP2AK39LtFN9Ayppu6hdCVKfMGVm79F2EgHCtsi",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23256/large/whey-coin-2048x2048.png?1643360509",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "whey-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Whole Earth Coin",
+      "symbol": "WEC",
+      "address": "6y8W5YwAuzostqrS4YDJufBvksosfSi47Pd8U4A5vrBC",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/16313/large/WEC_logo.png?1669459247",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "whole-earth-coin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Widi Soul",
+      "symbol": "WSO",
+      "address": "4TyXexYsJqy9n1vVFVkHn1CUxabP2cht3BSE74PSG1pq",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22832/large/wso2_200x200.png?1642668402",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "widi-soul"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Winerz",
+      "symbol": "$WNZ",
+      "address": "WNZzxM1WqWFH8DpDZSqr6EoHKWXeMx9NLLd2R5RzGPA",
+      "decimals": 4,
+      "logoURI": "https://assets.coingecko.com/coins/images/24786/large/wnz.png?1648905714",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "winerz"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WipeMyAss",
+      "symbol": "WIPE",
+      "address": "9ae76zqD3cgzR9gvf5Thc2NN3ACF7rqqnrLqxNzgcre6",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19967/large/wipemyass.jpeg?1636344049",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wipemyass"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wolfecoin",
+      "symbol": "WOLFE",
+      "address": "3KnVxWhoYdc9UwDr5WMVkZp2LpF7gnojg7We7MUd6ixQ",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/19647/large/ea2e65_7f14054a4493484ca8b88e2af221a28e_mv2.png?1635730036",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wolfecoin"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WOOF",
+      "symbol": "WOOF",
+      "address": "9nEqaUcb16sQ3Tn1psbkWqyhPdLmfHWjKGymREjsAgTE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/18319/large/woof-logo-svg-true-solana-radient-blackinside.png?1637655115",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "woof-token"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WOO Network",
+      "symbol": "WOO",
+      "address": "E5rk3nmgLUuKUiS94gg4bpWwWwyjCMtddsAXkTFLtHEy",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/12921/large/w2UiemF__400x400.jpg?1603670367",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "woo-network"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "WOOP",
+      "symbol": "WOOP",
+      "address": "A3HyGZqe451CBesNqieNPfJ4A9Mu332ui8ni6dobVSLB",
+      "decimals": 5,
+      "logoURI": "https://assets.coingecko.com/coins/images/24904/large/coin-gecko.png?1649335210",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "woop"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped ALGO",
+      "symbol": "XALGO",
+      "address": "xALGoH1zUfRmpCriy94qbfoMXHtK6NDnMKzT4Xdvgms",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/26335/large/xALGO.png?1657494713",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-algo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped Bitcoin (Sollet)",
+      "symbol": "SOBTC",
+      "address": "9n4nbM75f5Ui33ZbPYXn59EwSgE8CGsHtAeTH5YFeJ9E",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24917/large/opengraph.png?1649344256",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-bitcoin-sollet"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped BUSD (Allbridge from BSC)",
+      "symbol": "ABBUSD",
+      "address": "6nuaX3ogrr2CaoAPjtaKHAoBNWok32BMcRozuf32s2QF",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23061/large/logo_-_2022-01-26T091043.556.png?1643159457",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-busd-allbridge-from-bsc"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped CUSD (Allbridge from Celo)",
+      "symbol": "ACUSD",
+      "address": "EwxNF8g9UfmsJVcZFTpL9Hx5MCkoQFoJi6XNWzKf1j8e",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/23057/large/7236.png?1643153224",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-cusd-allbridge-from-celo"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped Ethereum (Sollet)",
+      "symbol": "SOETH",
+      "address": "2FPyTwcZLUg1MDrwsyoP4D6s1tM7hAkHYRjkNb5w6Pxk",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24918/large/6250754.png?1649344492",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-ethereum-sollet"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped Solana",
+      "symbol": "SOL",
+      "address": "So11111111111111111111111111111111111111112",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/21629/large/solana.jpg?1639626543",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-solana"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped USDT (Allbridge from Polygon)",
+      "symbol": "APUSDT",
+      "address": "DNhZkUaxHXYvpxZ7LNnHtss8sQgdAfd1ZYS1fB7LKWUZ",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/23060/large/logo_-_2022-01-26T084912.902.png?1643158161",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-usdt-allbridge-from-polygon"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Wrapped USTC",
+      "symbol": "USTC",
+      "address": "CXLBjMMcwkc17GfJtBos6rQCo1ypeH6eDbB82Kby4MRm",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/15462/large/ust.png?1620910058",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "wrapped-ust"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "xHashtag",
+      "symbol": "XTAG",
+      "address": "5gs8nf4wojB5EXgDUWNLwXpknzgV2YWDhveAeBZpVLbp",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/20912/large/xtag.png?1637922382",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "xhashtag"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Xverse",
+      "symbol": "XVC",
+      "address": "25Vu6457o2gdZRGVVt5K8NbAvaP3esYaQNHbNDitVtw1",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/17709/large/1_y5qvEWJiA4dFjoQNcqth3g.png?1629081157",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "xverse"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Yaku",
+      "symbol": "YAKU",
+      "address": "NGK3iHqqQkyRZUj4uhJDQqEyKKcZ7mdawWpqwMffM3s",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/26785/large/_YAKU_logo.png?1660101303",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "yaku"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Yawww",
+      "symbol": "YAW",
+      "address": "YAWtS7vWCSRPckx1agB6sKidVXiXiDUfehXdEUSRGKE",
+      "decimals": 6,
+      "logoURI": "https://assets.coingecko.com/coins/images/24233/large/yaw.PNG?1646982198",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "yawww"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Zap",
+      "symbol": "ZAP",
+      "address": "HxPoEHMt1vKeqjKCePcqTj6yYgn6Xqq1fKTY3Pjx4YrX",
+      "decimals": 8,
+      "logoURI": "https://assets.coingecko.com/coins/images/2180/large/zap.png?1547036476",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "zap"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Zebec Protocol",
+      "symbol": "ZBC",
+      "address": "zebeczgi5fSEtbpfQKVZKCJ3WgYXxjkMUkNNx7fLKAF",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/24342/large/zbc.PNG?1647400775",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "zebec-protocol"
+      }
+    },
+    {
+      "chainId": 101,
+      "name": "Zion",
+      "symbol": "ZION",
+      "address": "A7rqejP8LKN8syXMr4tvcKjs2iJ4WtZjXNs1e6qP3m9g",
+      "decimals": 9,
+      "logoURI": "https://assets.coingecko.com/coins/images/22150/large/Ziontoken_2_84.png?1640931619",
+      "tags": [],
+      "verified": true,
+      "holders": null,
+      "extensions": {
+        "coingeckoId": "zion"
+      }
+    }
+  ]
+}

--- a/data/solana/trusted-tokenlist.json
+++ b/data/solana/trusted-tokenlist.json
@@ -1,0 +1,35 @@
+{
+  "name": "Brave-trusted Solana Token List",
+  "logoURI": "",
+  "keywords": [
+    "solana",
+    "spl"
+  ],
+  "tags": {
+    "lp-token": {
+      "name": "lp-token",
+      "description": ""
+    }
+  },
+  "timestamp": "2023-02-03T06:30:17.435Z",
+  "tokens": [
+    {
+      "chainId": 101,
+      "address": "EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz",
+      "symbol": "BAT",
+      "name": "Basic Attention Token (Portal)",
+      "decimals": 8,
+      "logoURI": "https://raw.githubusercontent.com/solana-labs/token-list/main/assets/mainnet/EPeUFDgHRxs9xxEPVaL6kfGQvCon7jmAWKVUHuux1Tpz/logo.png",
+      "tags": [
+        "wrapped",
+        "wormhole"
+      ],
+      "extensions": {
+        "address": "0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "assetContract": "https://etherscan.io/address/0x0D8775F648430679A709E98d2b0Cb6250d2887EF",
+        "bridgeContract": "https://etherscan.io/address/0x3ee18B2214AFF97000D974cf647E7C347E8fa585",
+        "coingeckoId": "basic-attention-token"
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",
-    "@brave/spl-token-registry": "0.2.223",
+    "@solflare-wallet/utl-aggregator": "^0.0.11",
     "nodejs-file-downloader": "^4.9.3",
     "qyu": "^0.4.7",
     "sharp": "^0.30.5",
@@ -25,6 +25,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node scripts/index.js",
+    "gen:solana": "node scripts/solana.task.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "preinstall": "./isDocker.sh",
     "publish-token-package": "npm publish ./build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -5,7 +5,6 @@ import os from 'os'
 import path from 'path'
 
 // NPM imports
-import { TokenListProvider, Strategy } from '@brave/spl-token-registry'
 import { Qyu } from 'qyu'
 
 // Local module imports
@@ -159,13 +158,8 @@ async function stageTokenListsTokens(stagingDir, tokens, isEVM = true) {
 }
 
 async function stageSPLTokens(stagingDir) {
-  const splTokensProvider = await new TokenListProvider()
-    .resolve(Strategy.Static)
-
-  const splTokensArray = splTokensProvider
-    .filterByClusterSlug('mainnet-beta')
-    .getList()
-
+  const tokenMap = JSON.parse(fs.readFileSync(path.join('data', 'solana', 'tokenlist.json')).toString())
+  const splTokensArray = tokenMap.tokens
   const splTokens = await stageTokenListsTokens(stagingDir, splTokensArray, false)
   const splTokensPath = path.join(stagingDir, 'solana-contract-map.json')
   fs.writeFileSync(splTokensPath, JSON.stringify(splTokens, null, 2))

--- a/scripts/solana.task.js
+++ b/scripts/solana.task.js
@@ -1,0 +1,34 @@
+import path from 'path'
+import fs from 'fs'
+import fsPromises from 'fs/promises'
+
+import {
+  ChainId,
+  Generator,
+  ProviderCoinGecko,
+  ProviderTrusted
+} from '@solflare-wallet/utl-aggregator'
+
+async function generateTokensList () {
+  const trustedTokenList =
+    process.env.TRUSTED_TOKEN_LIST_URL ??
+    'https://cdn.jsdelivr.net/gh/brave/token-lists@main/data/solana/trusted-tokenlist.json'
+  const coinGeckoApiKey = process.env.COINGECKO_API_KEY ?? null
+  const rpcUrlMainnet = process.env.SOLANA_MAINNET_RPC_URL
+
+  const generator = new Generator([
+    ...(trustedTokenList ? [new ProviderTrusted(trustedTokenList, [], ChainId.MAINNET)] : []),
+    new ProviderCoinGecko(coinGeckoApiKey, rpcUrlMainnet, {
+      throttle: 200,
+      throttleCoinGecko: 65 * 1000,
+      batchAccountsInfo: 200,
+      batchCoinGecko: 5
+    })
+  ])
+
+  const tokenMap = await generator.generateTokenList()
+  fs.writeFileSync(path.join('data', 'solana', 'tokenlist.json'), JSON.stringify(tokenMap, null, 2))
+  return tokenMap
+}
+
+await generateTokensList()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,16 +2,16 @@
 # yarn lockfile v1
 
 
-"@brave/spl-token-registry@0.2.223":
-  version "0.2.223"
-  resolved "https://registry.yarnpkg.com/@brave/spl-token-registry/-/spl-token-registry-0.2.223.tgz#732f585862b16229e2243899f9667863027cdd59"
-  integrity sha512-22IruDy56WXxsFl6BHdg55JCEos1oyR0jQBtWKmaqa2WQeXGsmOHbC1P9pdserYUbarcNynqptYzaZb6PW0GiQ==
+"@babel/runtime@^7.15.4":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
   dependencies:
-    cross-fetch "^3.1.5"
+    regenerator-runtime "^0.13.11"
 
 "@metamask/contract-metadata@git+https://git@github.com/MetaMask/contract-metadata.git":
-  version "2.1.0"
-  resolved "git+https://git@github.com/MetaMask/contract-metadata.git#52934880018ace8fc61539ae36cb2a86cb9c2216"
+  version "2.2.0"
+  resolved "git+https://git@github.com/MetaMask/contract-metadata.git#e33453333c119bd15e1a85468a794dfcfb8a825f"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -38,6 +38,16 @@
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-5.3.0.tgz#0ec9264cf54a527671d990eb874e030b55b70dcc"
   integrity sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==
+
+"@solflare-wallet/utl-aggregator@^0.0.11":
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/@solflare-wallet/utl-aggregator/-/utl-aggregator-0.0.11.tgz#168bf7d5251abf2ac7b8e4c67eb64cd00f7c668d"
+  integrity sha512-bvMQhY8vuX2n4fm+2cnGj8/bBrTLqOktjtlGS2J/otlhsNUN8aKQuF+87cwiERt3ZcNSEGvFgarqpu3E/Hvkag==
+  dependencies:
+    axios "^0.27.2"
+    axios-retry "^3.2.5"
+    lodash "^4.17.21"
+    temp-dir "^2.0.0"
 
 "@szmarczak/http-timer@^5.0.1":
   version "5.0.1"
@@ -79,6 +89,27 @@ array-union@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-3.0.1.tgz#da52630d327f8b88cfbfb57728e2af5cd9b6b975"
   integrity sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw==
+
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+axios-retry@^3.2.5:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.4.0.tgz#f464dbe9408e5aa78fa319afd38bb69b533d8854"
+  integrity sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    is-retry-allowed "^2.2.0"
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -203,9 +234,9 @@ cacheable-lookup@^7.0.0:
   integrity sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==
 
 cacheable-request@^10.2.1:
-  version "10.2.3"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.3.tgz#25277efe121308ab722c28b4164e51382b4adeb1"
-  integrity sha512-6BehRBOs7iurNjAYN9iPazTwFDaMQavJO8W1MEm3s2pH8q/tkPTtLDRUZaweWK87WFGf2Y5wLAlaCJlR5kOz3w==
+  version "10.2.6"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-10.2.6.tgz#68f252932f448bdf49ccd03d1daf5506912df7ba"
+  integrity sha512-fhVLoXIFHvTizxQkAVohKPToSzdwzjrhL5SsjHT0umeSCxWeqJOS0oPqHg+yO1FPFST3VE5rxaqUvseyH9JHtg==
   dependencies:
     "@types/http-cache-semantics" "^4.0.1"
     get-stream "^6.0.1"
@@ -248,6 +279,13 @@ color@^4.2.3:
     color-convert "^2.0.1"
     color-string "^1.9.0"
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^2.20.0, commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -269,13 +307,6 @@ core-util-is@~1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
-
-cross-fetch@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
-  integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
-  dependencies:
-    node-fetch "2.6.7"
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -371,6 +402,11 @@ defer-to-connect@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz#8016bdb4143e4632b77a3449c6236277de520587"
   integrity sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 detect-libc@^2.0.0, detect-libc@^2.0.1:
   version "2.0.1"
@@ -507,9 +543,9 @@ fast-glob@^3.2.7:
     micromatch "^4.0.4"
 
 fastq@^1.6.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.13.0.tgz#616760f88a7526bdfc596b7cab8c18938c36b98c"
-  integrity sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
+  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
   dependencies:
     reusify "^1.0.4"
 
@@ -582,7 +618,7 @@ find-versions@^5.0.0:
   dependencies:
     semver-regex "^4.0.5"
 
-follow-redirects@^1.15.1:
+follow-redirects@^1.14.9, follow-redirects@^1.15.1:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -591,6 +627,15 @@ form-data-encoder@^2.1.2:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.4.tgz#261ea35d2a70d48d30ec7a9603130fa5515e9cd5"
   integrity sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -708,9 +753,9 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 http-cache-semantics@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
-  integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz#abe02fcb2985460bf0323be664436ec3476a6d5a"
+  integrity sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==
 
 http2-wrapper@^2.1.10:
   version "2.2.0"
@@ -749,9 +794,9 @@ ieee754@^1.1.13, ieee754@^1.2.1:
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 ignore@^5.1.9:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.1.tgz#c2b1f76cb999ede1502f3a226a9310fdfe88d46c"
-  integrity sha512-d2qQLzTJ9WxQftPAuEQpSPmKqzxePjzVbpAVv62AQ64NTL+wR4JkrVqR/LqFsFEUsHDAiId52mJteHDFuDkElA==
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
+  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 "imagemin-pngquant@github:onyb/imagemin-pngquant#fd51901":
   version "9.0.2"
@@ -842,6 +887,11 @@ is-png@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-png/-/is-png-2.0.0.tgz#ee8cbc9e9b050425cedeeb4a6fb74a649b0a4a8d"
   integrity sha512-4KPGizaVGj2LK7xwJIz8o5B2ubu1D/vcQsgOGFEDlpcvgZHto4gBnyd0ig7Ws+67ixmwKoNmu0hYnpo6AaKb5g==
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -945,7 +995,7 @@ mime-db@1.52.0, mime-db@^1.28.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27:
+mime-types@^2.1.12, mime-types@^2.1.27:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -1010,28 +1060,21 @@ ncp@~0.4.2:
   integrity sha512-PfGU8jYWdRl4FqJfCy0IzbkGyFHntfWygZg46nFk/dJD/XRrk2cj0SsKSX9n5u5gE0E0YfEpKWrEkfjnlZSTXA==
 
 node-abi@^3.3.0:
-  version "3.30.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.30.0.tgz#d84687ad5d24ca81cdfa912a36f2c5c19b137359"
-  integrity sha512-qWO5l3SCqbwQavymOmtTVuCWZE23++S+rxyoHjXqUmPyzRcaoI4lA2gO55/drddGnedAyjA7sk76SfQ5lfUMnw==
+  version "3.31.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.31.0.tgz#dfb2ea3d01188eb80859f69bb4a4354090c1b355"
+  integrity sha512-eSKV6s+APenqVh8ubJyiu/YhZgxQpGP66ntzUb3lY1xB9ukSRaGnx0AIxI+IM+1+IVYC1oWobgG5L3Lt9ARykQ==
   dependencies:
     semver "^7.3.5"
 
 node-addon-api@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.0.0.tgz#7d7e6f9ef89043befdb20c1989c905ebde18c501"
-  integrity sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==
-
-node-fetch@2.6.7:
-  version "2.6.7"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
-  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
-  dependencies:
-    whatwg-url "^5.0.0"
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-5.1.0.tgz#49da1ca055e109a23d537e9de43c09cca21eb762"
+  integrity sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==
 
 nodejs-file-downloader@^4.9.3:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/nodejs-file-downloader/-/nodejs-file-downloader-4.10.2.tgz#68a5b9b5b8b42719c6ed86500e7df30f30f308dc"
-  integrity sha512-pTVlytER/4wxcIpEhLXoqhuJ7WH1+xSFNLbI0wPmbwH3pWlJRRebb1Kbu91mz1CyOJmO4sj6YLH1wkF1B6efrQ==
+  version "4.10.6"
+  resolved "https://registry.yarnpkg.com/nodejs-file-downloader/-/nodejs-file-downloader-4.10.6.tgz#a2b6e2c721de14968cf6f8d7d980aac448217ea3"
+  integrity sha512-n9XK3+h1aSKbnf1dYvEiB6wd4rnzPz40IKBNuqr4zKlzfvc9AT69Vjf/X8+QwyOxsqYLY3/4etDZX97FKh27Jw==
   dependencies:
     follow-redirects "^1.15.1"
     https-proxy-agent "^5.0.0"
@@ -1315,6 +1358,11 @@ rechoir@^0.6.2:
   integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
   dependencies:
     resolve "^1.1.6"
+
+regenerator-runtime@^0.13.11:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz#f6dca3e7ceec20590d07ada785636a90cdca17f9"
+  integrity sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==
 
 replace-ext@^2.0.0:
   version "2.0.0"
@@ -1617,6 +1665,11 @@ temp-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
   integrity sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==
 
+temp-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-2.0.0.tgz#bde92b05bdfeb1516e804c9c00ad45177f31321e"
+  integrity sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==
+
 tempfile@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/tempfile/-/tempfile-2.0.0.tgz#6b0446856a9b1114d1856ffcbe509cccb0977265"
@@ -1649,11 +1702,6 @@ token-types@^4.1.1:
   dependencies:
     "@tokenizer/token" "^0.3.0"
     ieee754 "^1.2.1"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
 trim-repeated@^2.0.0:
   version "2.0.0"
@@ -1703,19 +1751,6 @@ uuid@>=8.3.2, uuid@^3.0.1:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
-
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
-
-whatwg-url@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
-  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 which@^1.2.9:
   version "1.3.1"


### PR DESCRIPTION
|Roadmap|https://github.com/brave/roadmap/issues/531|
-|-

The idea is to periodically generate Solana token list from Coingecko, in order to keep our blockchain registry up-to-date. This PR adds a cron task that fetches this list using Solflare's Unified Token List (UTL) aggregator, and commits the updates automatically to the repository.

If the above process is successful, we'll also publish an NPM package with the updated token list. See this example task run: https://github.com/brave/token-lists/actions/runs/4090965256/jobs/7054739078