### PR TITLE
chore: use admin access token for pushing commits

### DIFF
--- a/.github/workflows/solana-tokenlist.yml
+++ b/.github/workflows/solana-tokenlist.yml
@@ -40,7 +40,7 @@ jobs:
       - name: 'Automated Version Bump'
         uses: 'phips28/gh-action-bump-version@master'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN_LIST }}
 
       - run: yarn start
 


### PR DESCRIPTION
We're unable to push commits using `GITHUB_TOKEN`. Using `REPO_TOKEN_LIST` instead, which is configured to have admin access.