### PR TITLE
Reduce dapp-lists.json file size by about 2/3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -435,11 +435,19 @@ const generateDappLists = async () => {
     }
 
     const dapps = await response.json()
-    dappLists[chain] = dapps
+
+    // Remove socialLinks and fullDescription from each dApp object
+    const filteredDapps = dapps.results.map(dapp => {
+      const { socialLinks, fullDescription, ...filteredDapp } = dapp
+      return filteredDapp
+    })
+
+    dappLists[chain] = filteredDapps
   }
 
   return dappLists
 }
+
 
 module.exports = {
   contractReplaceSvgToPng,


### PR DESCRIPTION
Remove the social links and the fullDescription fields from the DappRadar response because these aren't going to be used by core and they take up a lot of space.

Previously 1.63MB, now 580k.