### PR TITLE
Fix two issues with the dapp-lists 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.5.3",
+  "version": "1.6.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -437,12 +437,12 @@ const generateDappLists = async () => {
     const dapps = await response.json()
 
     // Remove socialLinks and fullDescription from each dApp object
-    const filteredDapps = dapps.results.map(dapp => {
+    dapps.results = dapps.results.map(dapp => {
       const { socialLinks, fullDescription, ...filteredDapp } = dapp
       return filteredDapp
     })
 
-    dappLists[chain] = filteredDapps
+    dappLists[chain] = dapps
   }
 
   return dappLists

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -422,7 +422,7 @@ const generateDappLists = async () => {
   const top = 100
   const dappLists = {}
 
-  for (const chain of chains) {
+  for (let chain of chains) {
     const url = `https://api.dappradar.com/${dappRadarProjectId}/dapps/top/${metric}?chain=${chain}&range=${range}&top=${top}`
     const response = await fetch(url, {
       headers: {
@@ -442,6 +442,12 @@ const generateDappLists = async () => {
       return filteredDapp
     })
 
+    // Replace 'binance-smart-chain' with 'binance_smart_chain' so it plays well
+    // with the browser JSON parser.
+    if (chain  === 'binance-smart-chain') {
+      chain = 'binance_smart_chain'
+    }
+    
     dappLists[chain] = dapps
   }
 


### PR DESCRIPTION
* Replace 'binance-smart-chain' key with 'binance_smart_chain'

  The generated JSON parser on the client was having trouble with the key
  that used dashes.

* Fix bug filtering dapp lists (regression)

  Instead of just filtering dapps.results.socialLinks and
  dapps.results.fullDescription, the previous code replaced dapps with the
  filterd dapps.results.

  This change keeps the filtering of dapps.results, but does not remove
  the other sibiling keys.
