### PR TITLE
chore: add Binance-Peg BUSD to Polygon

### DIFF
--- a/data/evm-contract-map/evm-contract-map.json
+++ b/data/evm-contract-map/evm-contract-map.json
@@ -53,8 +53,17 @@
     "coingeckoId": "wrapped-ust",
     "chainId": "0x89"
   },
+  "0x9c9e5fd8bbc25984b178fdce6117defa39d2db39": {
+    "name": "Binance-Peg BUSD",
+    "logo": "busd.png",
+    "erc20": true,
+    "symbol": "BUSD",
+    "decimals": 18,
+    "coingeckoId": "binance-usd",
+    "chainId": "0x89"
+  },
   "0xdAb529f40E671A1D4bF91361c21bf9f0C9712ab7": {
-    "name": "Binance USD",
+    "name": "Binance USD (Paxos)",
     "logo": "busd.png",
     "erc20": true,
     "symbol": "BUSD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",


### PR DESCRIPTION
On Polygon, user may have a BUSD balance on the following two contracts.
- [Binance-Peg BUSD](https://polygonscan.com/token/0x9c9e5fd8bbc25984b178fdce6117defa39d2db39)  -  a product by Binance.
- [Binance USD (Paxos)](https://polygonscan.com/token/0xdab529f40e671a1d4bf91361c21bf9f0c9712ab7)  -  product by Paxos.

