### PR TITLE
Augment on-ramp-currencies-lists.json with Sardine data fetched dynamically from API

### DIFF
--- a/data/onramps/on-ramp-currency-lists.json
+++ b/data/onramps/on-ramp-currency-lists.json
@@ -33,14 +33,16 @@
       "currency_name": "British pound",
       "providers": [
         "ramp",
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
       "currency_code": "CAD",
       "currency_name": "Canadian dollar",
       "providers": [
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
@@ -76,7 +78,8 @@
       "currency_name": "Euro",
       "providers": [
         "ramp",
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
@@ -211,7 +214,9 @@
       "providers": [
         "ramp",
         "transak",
-        "stripe"
+        "stripe",
+        "sardine",
+        "coinbase"
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -244,9 +244,13 @@ async function stageOnRampLists(stagingDir) {
   rampTokens = await util.addSupportedCoinbaseTokens(rampTokens);
   await fsPromises.writeFile(dstRampTokensPath, JSON.stringify(rampTokens, null, 2));
 
+  // on-ramp-currency-lists.json
   const srcOnRampCurrenciesPath = path.join('data', 'onramps', 'on-ramp-currency-lists.json');
   const dstOnRampCurrenciesPath = path.join(stagingDir, 'on-ramp-currency-lists.json');
-  await fsPromises.copyFile(srcOnRampCurrenciesPath, dstOnRampCurrenciesPath);
+  const srcOnRampCurrenciesData = await fsPromises.readFile(srcOnRampCurrenciesPath, 'utf-8');
+  let onRampCurrencies = JSON.parse(srcOnRampCurrenciesData);
+  onRampCurrencies = await util.addSupportedSardineCurrencies(onRampCurrencies);
+  await fsPromises.writeFile(dstOnRampCurrenciesPath, JSON.stringify(onRampCurrencies, null, 2));
 }
 
 async function stageTokenPackage() {

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -567,7 +567,7 @@ const addSupportedSardineCurrencies = async (onRampCurrencies) => {
       // If the currency doesn't exist, create a new entry
       const newCurrency = {
         currency_code: currencyCode,
-        // currency_name: "", // TODO - This isn't available.
+        currency_name: "",
         providers: [sardine],
       };
       onRampCurrencies.currencies.push(newCurrency);


### PR DESCRIPTION
Resolves https://github.com/brave/token-lists/issues/77
Resolves https://github.com/brave/token-lists/issues/78

Note: The currencies supported by Sardine only will have an empty string for the currency_name.