### PR TITLE
Add coinbase to list of supported providers for USD, EUR, CAD, and GBP

### DIFF
--- a/data/onramps/on-ramp-currency-lists.json
+++ b/data/onramps/on-ramp-currency-lists.json
@@ -33,14 +33,16 @@
       "currency_name": "British pound",
       "providers": [
         "ramp",
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
       "currency_code": "CAD",
       "currency_name": "Canadian dollar",
       "providers": [
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
@@ -76,7 +78,8 @@
       "currency_name": "Euro",
       "providers": [
         "ramp",
-        "transak"
+        "transak",
+        "coinbase"
       ]
     },
     {
@@ -211,7 +214,9 @@
       "providers": [
         "ramp",
         "transak",
-        "stripe"
+        "stripe",
+        "sardine",
+        "coinbase"
       ]
     }
   ]


### PR DESCRIPTION
I confirmed with the Coinbase team that these were the only supported currencies.  See `presetFiatAmount` in their docs https://docs.cloud.coinbase.com/pay-sdk/docs/integrating-pay#widgetparameters-parameters.