### PR TITLE
Add logic to output ofac-sanctioned-digital-currency-addresses.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -253,6 +253,12 @@ async function stageOnRampLists(stagingDir) {
   await fsPromises.writeFile(dstOnRampCurrenciesPath, JSON.stringify(onRampCurrencies, null, 2));
 }
 
+async function stageOFACLists(stagingDir) {
+  const ofacLists = util.fetchGitHubRepoTopLevelFiles('brave-intl', 'ofac-sanctioned-digital-currency-addresses', 'lists');
+  const dstOfacListsPath = path.join(stagingDir, 'ofac-sanctioned-digital-currency-addresses.json');
+  await fsPromises.writeFile(dstOfacListsPath, JSON.stringify(ofacLists, null, 2));
+}
+
 async function stageTokenPackage() {
   const stagingDir = 'build'
   if (!fs.existsSync(stagingDir)) {
@@ -290,6 +296,9 @@ async function stageTokenPackage() {
 
   // Add on ramp JSON files
   await stageOnRampLists(stagingDir)
+
+  // Add OFAC banned address lists
+  await stageOFACLists(stagingDir)
 
   stagePackageJson(stagingDir)
   stageManifest(stagingDir)

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -254,7 +254,7 @@ async function stageOnRampLists(stagingDir) {
 }
 
 async function stageOFACLists(stagingDir) {
-  const ofacLists = util.fetchGitHubRepoTopLevelFiles('brave-intl', 'ofac-sanctioned-digital-currency-addresses', 'lists');
+  const ofacLists = await util.fetchGitHubRepoTopLevelFiles('brave-intl', 'ofac-sanctioned-digital-currency-addresses', 'lists');
   const dstOfacListsPath = path.join(stagingDir, 'ofac-sanctioned-digital-currency-addresses.json');
   await fsPromises.writeFile(dstOfacListsPath, JSON.stringify(ofacLists, null, 2));
 }

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -688,7 +688,7 @@ const fetchGitHubFileContent = async (repoOwner, repoName, branch, filePath, git
 };
 
 const fetchGitHubRepoTopLevelFiles = async (repoOwner, repoName, branch) => {
-  const githubToken = process.env.GITHUB_TOKEN;
+  const githubToken = process.env.API_AUTH_TOKEN_GITHUB;
   const githubHeaders = {
       "Accept": "application/vnd.github.v3+json",
       "Authorization": `token ${githubToken}`

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -694,26 +694,7 @@ const fetchGitHubRepoTopLevelFiles = async (repoOwner, repoName, branch) => {
       "Authorization": `token ${githubToken}`
   };
 
-  const chainIdLookup = {
-    'ARB': '0xa4b1',
-    'BCH': 'BCH',
-    'BSC': '0x38',
-    'BSV': 'BSV',
-    'BTG': 'BTG',
-    'DASH': 'DASH',
-    'ETC': '0x3d',
-    'ETH': '0x1',
-    'LTC': 'LTC',
-    'USDT': '0x1',
-    'XBT': 'bitcoin_mainnet',
-    'XMR': 'XMR',
-    'XRP': 'XRP',
-    'XVG': 'XVG',
-    'ZEC': 'ZEC'
-  };
-
   const apiUrl = `https://api.github.com/repos/${repoOwner}/${repoName}/git/trees/${branch}?recursive=1`;
-
   const response = await fetch(apiUrl, { headers: githubHeaders });
   const data = await response.json();
 
@@ -732,20 +713,15 @@ const fetchGitHubRepoTopLevelFiles = async (repoOwner, repoName, branch) => {
       }
   }
 
-  const aggregatedData = {};
+  let bannedAddresses = []
   for (const file of jsonFiles) {
     const content = await fetchGitHubFileContent(repoOwner, repoName, branch, file.path, githubHeaders); 
-    const parsedContent = JSON.parse(content);
-    
-    const chainIdSymbol = file.path.replace('sanctioned_addresses_', '').replace('.json', '');
-
-    const numericalChainId = chainIdLookup[chainIdSymbol];
-
-    aggregatedData[numericalChainId] = parsedContent;
+    const bannedAddressesForFile = JSON.parse(content);
+    bannedAddresses = [...bannedAddressesForFile, ...bannedAddresses]
   }
+  bannedAddresses = [...new Set(bannedAddresses)]
 
-  console.log(aggregatedData);
-  return aggregatedData
+  return {"bannedAddresses": bannedAddresses}
 }
 
 

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -721,7 +721,7 @@ const fetchGitHubRepoTopLevelFiles = async (repoOwner, repoName, branch) => {
   }
   bannedAddresses = [...new Set(bannedAddresses)]
 
-  return {"bannedAddresses": bannedAddresses}
+  return {"addresses": bannedAddresses}
 }
 
 


### PR DESCRIPTION
Generates a new file `ofac-sanctioned-digital-currency-addresses.json`, that looks like this:
```
{
   "addresses": [<address1>, <address2>]
}
```

It's just a flat list of addresses to not send transfers to, and includes every coin type (e.g. bitcoin, EVM, and Solana addresses are all included in the one array).

The list is generated by parsing the `lists` branch of this repo https://github.com/brave-intl/ofac-sanctioned-digital-currency-addresses/tree/lists.  That repo has a daily job that scrapes the digital currency addresses from the OFAC website, and outputs them in `sanctioned_addresses_*.json` files at the top level of the github repo.

In order to fetch those files from our github repo, the code in this change uses the github API, which requires an authentication token `GITHUB_TOKEN` , which must be added as an environment variable to this repo.

That list is parsed clientside and checked prior to regular transfers and token transfers in brave-core in this [pull request](https://github.com/brave/brave-core/pull/20375).

Security review - https://github.com/brave/reviews/issues/1273.
