### PR TITLE
Use Ankr to generate token lists

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -30,6 +30,12 @@ async function stageEVMTokenFile(stagingDir, inputTokenFilePath, coingeckoIds) {
   )
 }
 
+async function stageCombinedTokenFile(stagingDir, coingeckoIds) {
+  const dstPath = path.join(stagingDir, 'token-lists.json')
+  const tokenLists = await util.generateTokenList(coingeckoIds)
+  fs.writeFileSync(dstPath, JSON.stringify(tokenLists, null, 2))
+}
+
 async function stageMainnetTokenFile(stagingDir, inputTokenFilePath, coingeckoIds) {
   // Read in the JSON file located at inputTokenFilePath
   const tokenList = JSON.parse(fs.readFileSync(inputTokenFilePath, 'utf-8'))
@@ -266,6 +272,9 @@ async function stageTokenPackage() {
   if (!fs.existsSync(imagesDstPath)){
     fs.mkdirSync(imagesDstPath)
   }
+
+  // Generate combined token list
+  await stageCombinedTokenFile(stagingDir, coingeckoIds)
 
   // Add MetaMask tokens for contract-map.json
   const metamaskTokenPath = path.join('node_modules', '@metamask', 'contract-metadata', 'contract-map.json');

--- a/scripts/util.cjs
+++ b/scripts/util.cjs
@@ -280,6 +280,63 @@ const installErrorHandlers = () => {
   })
 }
 
+const generateTokenList = async (coingeckoIds) => {
+    const ankrApiKey = process.env.ANKR_API_KEY
+    const ankrSupportedChains = {
+        "eth": "0x1",
+        "bsc": "0x38",
+        "fantom": "0xfa",
+        "avalanche": "0xa86a",
+        "polygon": "0x89",
+        "optimism": "0xa",
+    };
+
+    const tokenList = {};
+
+    for (let chainKey in ankrSupportedChains) {
+        let chainId = ankrSupportedChains[chainKey];
+
+        const response = await fetch(`https://rpc.ankr.com/multichain/${ankrApiKey}/?ankr_getCurrencies=`, {
+            method: 'POST',
+            headers: {
+                'accept': 'application/json',
+                'content-type': 'application/json'
+            },
+            body: JSON.stringify({
+                "jsonrpc": "2.0",
+                "method": "ankr_getCurrencies",
+                "params": {
+                    "blockchain": chainKey
+                },
+                "id": 1
+            })
+        });
+
+        const data = await response.json();
+
+        if (data.result && data.result.currencies) {
+            let tokens = data.result.currencies;
+            let tokenMapping = {};
+
+            for (let token of tokens) {
+                let coingeckoId = coingeckoIds[chainId] && coingeckoIds[chainId][token.address] ? coingeckoIds[chainId][token.address] : null;
+                tokenMapping[token.address] = {
+                    "name": token.name,
+                    "logo": token.thumbnail,
+                    "symbol": token.symbol,
+                    "decimals": token.decimals,
+                    "coingeckoId": coingeckoId,
+                    "erc20": true,
+                };
+            }
+
+            tokenList[chainId] = tokenMapping;
+        }
+    }
+
+    return tokenList;
+}
+
 const generateMainnetTokenList = async (fullTokenList) => {
   const MAX_TOKEN_LIST_SIZE = 100
   const coinGeckoApiBaseUrl = 'https://api.coingecko.com/api/v3'
@@ -679,6 +736,7 @@ module.exports = {
   installErrorHandlers,
   saveToPNGResize,
   download,
+  generateTokenList,
   generateMainnetTokenList,
   generateDappLists,
   addSupportedCoinbaseTokens,


### PR DESCRIPTION
Resolves https://github.com/brave/token-lists/issues/82
Resolves https://github.com/brave/token-lists/issues/84


## Remaining work and other issues
I was going to cache is_erc20 values similar to how we are caching coingecko IDs (since Ankr does not include this information), but I couldn't find a way to look up whether a given token is an ERC20 (previously thought this would be possible via an on-chain supportsInterface contract call, but ERC20s don't seem to support ERC165...).  So that's still TBD.

We need to add native tokens which are not included in the Ankr response.

We need to download and compress images in for the tokens similar to how we are doing already. 