### PR TITLE
Expose API_AUTH_TOKEN_GITHUB in GitHub workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -8,6 +8,7 @@ env:
   TOKEN_LISTS_ACTIONS_OR_CI_BUILD: true
   DAPP_RADAR_PROJECT_ID: ${{ secrets.DAPP_RADAR_PROJECT_ID }}
   DAPP_RADAR_API_KEY: ${{ secrets.DAPP_RADAR_API_KEY }}
+  API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ env:
   TOKEN_LISTS_ACTIONS_OR_CI_BUILD: true
   DAPP_RADAR_PROJECT_ID: ${{ secrets.DAPP_RADAR_PROJECT_ID }}
   DAPP_RADAR_API_KEY: ${{ secrets.DAPP_RADAR_API_KEY }}
+  API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
 
 jobs:
   build:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,6 +12,7 @@ env:
   TOKEN_LISTS_ACTIONS_OR_CI_BUILD: true
   DAPP_RADAR_PROJECT_ID: ${{ secrets.DAPP_RADAR_PROJECT_ID }}
   DAPP_RADAR_API_KEY: ${{ secrets.DAPP_RADAR_API_KEY }}
+  API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
 
 jobs:
   publish-npm:

--- a/.github/workflows/solana-tokenlist.yml
+++ b/.github/workflows/solana-tokenlist.yml
@@ -10,6 +10,7 @@ env:
   TOKEN_LISTS_ACTIONS_OR_CI_BUILD: true
   DAPP_RADAR_PROJECT_ID: ${{ secrets.DAPP_RADAR_PROJECT_ID }}
   DAPP_RADAR_API_KEY: ${{ secrets.DAPP_RADAR_API_KEY }}
+  API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
 
 jobs:
   generate:


### PR DESCRIPTION
These were missing from https://github.com/brave/token-lists/pull/81