### PR TITLE
Fix Solana UTL generation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.14.1",
+  "version": "1.15.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/solana.task.js
+++ b/scripts/solana.task.js
@@ -5,28 +5,52 @@ import {
   Generator,
   ProviderCoinGecko,
   ProviderTrusted,
-  ChainId
-} from "@solflare-wallet/utl-aggregator"
+  ProviderIgnore,
+  ChainId,
+  Tag,
+} from '@solflare-wallet/utl-aggregator'
 
-async function generateTokensList () {
+const sec = 1000
+
+async function generateTokensList() {
   const trustedTokenList =
     process.env.TRUSTED_TOKEN_LIST_URL ??
     'https://cdn.jsdelivr.net/gh/brave/token-lists@main/data/solana/trusted-tokenlist.json'
   const coinGeckoApiKey = process.env.COINGECKO_API_KEY ?? null
   const rpcUrlMainnet = process.env.SOLANA_MAINNET_RPC_URL
 
-  const generator = new Generator([
-    ...(trustedTokenList ? [new ProviderTrusted(trustedTokenList, [], ChainId.MAINNET)] : []),
-    new ProviderCoinGecko(coinGeckoApiKey, rpcUrlMainnet, {
-      throttle: 200,
-      throttleCoinGecko: 65 * 1000,
-      batchAccountsInfo: 200,
-      batchCoinGecko: 5
-    })
-  ])
+  const generator = new Generator(
+    [
+      ...(trustedTokenList
+        ? [
+            new ProviderTrusted(
+              trustedTokenList,
+              [Tag.LP_TOKEN],
+              ChainId.MAINNET
+            ),
+          ]
+        : []),
+      new ProviderCoinGecko(coinGeckoApiKey, rpcUrlMainnet, {
+        throttle: 200,
+        throttleCoinGecko: 65 * sec,
+        batchAccountsInfo: 200,
+        batchCoinGecko: 5,
+      }),
+    ],
+    [
+      new ProviderIgnore(
+        'https://raw.githubusercontent.com/solflare-wallet/token-list/master/ignore-tokenlist.json',
+        [],
+        ChainId.MAINNET
+      ),
+    ]
+  )
 
   const tokenMap = await generator.generateTokenList()
-  fs.writeFileSync(path.join('data', 'solana', 'tokenlist.json'), JSON.stringify(tokenMap, null, 2))
+  fs.writeFileSync(
+    path.join('data', 'solana', 'tokenlist.json'),
+    JSON.stringify(tokenMap, null, 2)
+  )
   return tokenMap
 }
 


### PR DESCRIPTION
Looks like `@solflare-wallet/utl-aggregator` now expects us to mandatorily provide a source containing tokens to ignore, otherwise it fails during list generation.