### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We have setup a **weekly** cron job on [Jenkins](https://github.com/brave/devops
 
 ### Docker
 
-- Install [docker](https://runnable.com/docker/)
+- Install [docker](https://sb-biodatacatalyst.readme.io/docs/install-docker)
 - Create a docker image `docker build -t token-lists .`
 - Launch the docker image `docker run -u "$(id -u):$(id -g)" -v "$PWD/build:/token-lists/build" -ti token-lists`
 - You will see an output in the `build` folder


### PR DESCRIPTION
The old URL is unable to redirect me to the correct link, I have changed it to the right link.

Please correct me if I'm wrong, maybe I'm just paranoid, but the original link looks weird to me. That website the old doc redirect me to is marked `Not Secure` by Brave browser itself. Bottom part that says `Docs` and `Docker Guides` are down, FAQ link is also down. Somehow there is also a pricing tab, which I was  taught to not share any sensitive information over an unsecure website.