### PR TITLE
Fix casing in token symbols from Coingecko API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.25.155",
+  "version": "1.26.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",


### PR DESCRIPTION
Token symbols returned by Coingecko API are always in lowercase. Turns out that the symbol string stored in the onchain contracts have more reliable casing as the developers originally intended, for example, USDe instead of USDE.