### PR TITLE
Translate NEAR token accounts to EVM-compatible addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",


### PR DESCRIPTION
> I wasn't aware that Near exposed a ETH-JSON RPC and supported EVM addresses.
>
> By the way, would you know if there a way to resolve `aaaaaa20d9e0e2461697782ef11675f668207961.factory.bridge.near` into `0x38e0355ecD67b979909c8Ad80596Caf47746B792` (for AURORA, for ex)? This way we can programmatically populate this from https://api.coingecko.com/api/v3/coins/list?include_platform=true

_Originally posted by @onyb in https://github.com/brave/token-lists/issues/156#issuecomment-2465209128_
            
--

Coingecko API currently lists 72 NEAR Protocol tokens, but does not include EVM-compatible addresses that can be accessed via Near EVM.

I was finally able to figure out the EVM-encoding logic from the responses of nearblocks.io network calls, and it looks like this is NEP-518. NEAR account IDs can apparently be encoded into EVM-compatible addresses by taking right-most 20 bytes of the Keccak-256 hash of the binary account ID.

**TL;DR:** Brave Wallet users can now add Near Protocol tokens on the EVM layer, and benefit from accurate price lookups.

| SPEC | https://github.com/near/NEPs/issues/518 |
-|-

Resolves https://github.com/brave/brave-browser/issues/41279