### PR TITLE
Add missing ERC20 symbol() ABI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",

--- a/scripts/coingecko-universe.ts
+++ b/scripts/coingecko-universe.ts
@@ -209,13 +209,23 @@ const getTokenChainInfo = async (chainId: ChainId, address: string) => {
   const provider = new ethers.JsonRpcProvider(rpcUrl)
   const contract = new ethers.Contract(
     address,
-    ['function decimals() view returns (uint8)'],
+    [
+      'function decimals() view returns (uint8)',
+      'function symbol() view returns (string)'
+    ],
     provider,
   )
 
+  let symbol: string | undefined;
+  try {
+    symbol = await contract.symbol();
+  } catch (error) {
+    // Symbol is optional, so we continue without it
+  }
+
   return {
     decimals: Number(await contract.decimals()),
-    symbol: await contract.symbol(),
+    symbol,
   }
 }
 


### PR DESCRIPTION
If the `eth_call` to extract the onchain `symbol` string fails, we should fallback on using the one provided by Coingecko API.

Also, specify the ABI for `symbol()` function as required by ethers JS.