### PR TITLE
Harden decimal and symbol resolution using Coingecko API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "token-lists",
-  "version": "1.28.0",
+  "version": "1.29.0",
   "description": "Manages custom token lists for Brave Wallet",
   "dependencies": {
     "@metamask/contract-metadata": "git+https://git@github.com/MetaMask/contract-metadata.git",


### PR DESCRIPTION
Querying the decimals from RPC may fails, so in such a case, we obtain it by fetching the detailed info for the associated Coingecko market.