### PR TITLE
Move published package to @brave/wallet-lists scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # token-lists
 
-[![Build](https://github.com/brave/token-lists/actions/workflows/build.yml/badge.svg)](https://github.com/brave/token-lists/actions/workflows/build.yml) [![npm version](https://badge.fury.io/js/brave-wallet-lists.svg)](https://badge.fury.io/js/brave-wallet-lists)
+[![Build](https://github.com/brave/token-lists/actions/workflows/build.yml/badge.svg)](https://github.com/brave/token-lists/actions/workflows/build.yml) [![npm version](https://badge.fury.io/js/@brave%2Fwallet-lists.svg)](https://badge.fury.io/js/@brave%2Fwallet-lists)
 
 Manages custom token lists for Brave Wallet
 
@@ -54,7 +54,7 @@ pnpm lint
 
 ## Publishing token list to npm
 
-[brave/brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager) uses the npm package published [here brave-wallet-lists](https://www.npmjs.com/package/brave-wallet-lists). It will be automatically published when your
+[brave/brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager) uses the npm package published [here @brave/wallet-lists](https://www.npmjs.com/package/@brave/wallet-lists). It will be automatically published when your
 PR is merged and a new release is created.
 
 This produces a zero-dependency package with output images and token lists.

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -8,7 +8,8 @@ const util = require('./util.cjs')
 
 function stagePackageJson (stagingDir) {
   const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf-8'))
-  packageJson.name = 'brave-wallet-lists'
+  packageJson.name = '@brave/wallet-lists'
+  packageJson.publishConfig = { access: 'public' }
   packageJson.scripts = {}
   packageJson.devDependencies = {}
   packageJson.dependencies = {}


### PR DESCRIPTION
## Summary
- Renames the published npm package from `brave-wallet-lists` to `@brave/wallet-lists`, moving it under the [`@brave` npm organization](https://www.npmjs.com/org/brave) for better management (closes #21)
- Adds `publishConfig.access=public` to the staged `package.json` so the scoped package is published publicly (scoped packages default to private on npm)
- Updates README badge and the link to the published package

## Breaking change
Consumers — notably [brave/brave-core-crx-packager](https://github.com/brave/brave-core-crx-packager) — will need to update their dependency name from `brave-wallet-lists` to `@brave/wallet-lists` after this is merged and the first release publishes under the new name.

## Test plan
- [ ] Confirm CI `Build` workflow passes (`pnpm install`, `pnpm lint`, `pnpm start`)
- [ ] Verify the generated `build/package.json` has `"name": "@brave/wallet-lists"` and `"publishConfig": { "access": "public" }`
- [ ] On the next Auto Release run, confirm `npm publish ./build` succeeds and the package appears at https://www.npmjs.com/package/@brave/wallet-lists
- [ ] Coordinate with `brave-core-crx-packager` to update the dependency name once the new package is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)