### PR TITLE
ci: harden the npm publish script (#329)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,10 +6,6 @@ on:
     # At 01:00 (1 AM) every day
     - cron: '0 1 * * *'
 
-env:
-  COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
-  API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
-
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -38,7 +34,7 @@ jobs:
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Bump patch version
         id: bump-version
@@ -48,6 +44,9 @@ jobs:
 
       - name: Build assets
         run: pnpm start
+        env:
+          COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
+          API_AUTH_TOKEN_GITHUB: ${{ secrets.API_AUTH_TOKEN_GITHUB }}
 
       - name: Bump version and commit build assets
         run: |


### PR DESCRIPTION
Fixes #329

### Description

This PR addresses the security risks outlined in #329 regarding the exposure of environment secrets during the dependency installation phase of the scheduled auto-release.yml workflow.

Previously, COINGECKO_API_KEY and API_AUTH_TOKEN_GITHUB were declared at the top-level env block. Because this workflow runs on a daily cron schedule (0 1 * * *) and executes pnpm start (which can trigger install hooks), a compromised transitive dependency could potentially run malicious scripts and silently exfiltrate these broadly scoped secrets.

### Changes Made
Scoped Environment Secrets: Removed the global env block and moved COINGECKO_API_KEY and API_AUTH_TOKEN_GITHUB directly into the Build assets step. This restricts secret access strictly to the step that requires them.

Disabled Install Scripts: Added the --ignore-scripts flag to the pnpm install --frozen-lockfile step to prevent the execution of arbitrary scripts from dependencies during the setup phase.

### So Impact would be 

These changes mitigate the highest-risk finding in the repository by ensuring secrets are isolated from the dependency installation and build setup phases, protecting the automated nightly runs from unauthorized secret exfiltration.