### PR TITLE
Add copy of ofac sanctioned addresses to prohibited-addresses.json

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -73,6 +73,8 @@ const stageOFACLists = async (stagingDir: string): Promise<void> => {
   );
   const dstOfacListsPath = path.join(stagingDir, 'ofac-sanctioned-digital-currency-addresses.json');
   await fsPromises.writeFile(dstOfacListsPath, JSON.stringify(ofacLists, null, 2));
+  const dstProhibitedAddressesPath = path.join(stagingDir, 'prohibited-addresses.json');
+  await fsPromises.writeFile(dstProhibitedAddressesPath, JSON.stringify(ofacLists, null, 2));
 };
 
 const stageCoingeckoTokenList = async (stagingDir: string, filename: string): Promise<void> => {


### PR DESCRIPTION
Adding a copy of OFAC sanctioned addresses in `prohibited-addresses.json` (requested by Compliance). We'll eventually drop `ofac-sanctioned-digital-currency-addresses.json` in favour of this, once brave-core migrates to the new name.